### PR TITLE
v0.5.3-r1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.5.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053---jan-7-2023) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/master/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.5.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053-r1---mar-9-2023) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/master/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -98,7 +98,7 @@ Recommended:
 
 Release Notes:
 ---
-For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053---jan-7-2023)
+For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053-r1---mar-9-2023)
 
 Congratulations!!
 ---

--- a/lamw_manager/core/installer/configure.sh
+++ b/lamw_manager/core/installer/configure.sh
@@ -487,6 +487,7 @@ printOK(){
 }
 printFail(){
 	printf "%s\n" "${FILLER:${#1}}${VERMELHO} [FAILS]${NORMAL}"
+	echo "Please, get more info in https://github.com/dosza/LAMWManager-linux/blob/master/lamw_manager/docs/other-distros-info.md#compatible-linux-distro"
 }
 
 systemHasLibsToBuildLazarus(){

--- a/lamw_manager/core/installer/configure.sh
+++ b/lamw_manager/core/installer/configure.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+declare -i X11_INDEX=11
+declare -i GTK2_INDEX=265
+declare -i GDK_INDEX=278
+declare -i CAIRO_INDEX=292
+declare -i PANGO_INDEX=326
+declare -i XTST_INDEX=328
+declare -i ATK_INDEX=362
+declare -i FREEGLUT_INDEX=366
+
 declare -A LIBS_DEB_EQUIVALENT=(
 	['libgdk-x11-2.0.so']=libgtk2.0-dev
 	['libgtk-x11-2.0.so']=libx11-dev
@@ -17,15 +26,17 @@ declare -A LIBS_DEB_EQUIVALENT=(
 	['libglut.so']='freeglut3-deb.so freeglut3-dev'
 )
 
+
+
 declare -A HEADERS_EQUIVALENT_DEB=(
-	['11']=libx11-dev
-	['265']=libgtk2.0-dev
-	['278']=libgdk-pixbuf2.0-dev
-	['292']=libcairo2-dev
-	['327']=libpango1.0-dev
-	['329']=libxtst-dev
-	['363']=libatk1.0-dev
-	['367']=freeglut3-dev
+	[$X11_INDEX]=libx11-dev
+	[$GTK2_INDEX]=libgtk2.0-dev
+	[$GDK_INDEX]=libgdk-pixbuf2.0-dev
+	[$CAIRO_INDEX]=libcairo2-dev
+	[$PANGO_INDEX]=libpango1.0-dev
+	[$XTST_INDEX]=libxtst-dev
+	[$ATK_INDEX]=libatk1.0-dev
+	[$FREEGLUT_INDEX]=freeglut3-dev
 )
 
 
@@ -355,7 +366,7 @@ HEADERS=(
 	/usr/include/cairo/cairo-script-interpreter.h
 	/usr/include/cairo/cairo-script.h
 	/usr/include/cairo/cairo-svg.h
-	/usr/include/cairo/cairo-tee.h
+	#/usr/include/cairo/cairo-tee.h
 	/usr/include/cairo/cairo-version.h
 	/usr/include/cairo/cairo-xcb.h
 	/usr/include/cairo/cairo-xlib-xrender.h
@@ -440,33 +451,35 @@ HEADERS=(
 
 MESSAGE_INSTALL='Install on your system the package equivalent to:'
 
+
 showPackageNameByIndex(){
 	local -i index=$1
 
-	if [ $index -le  11 ]; then 
-		echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[11]}"
+	if [ $index -le  $X11_INDEX ]; then 
+		echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$X11_INDEX]}"
 		
-		elif [ $index -le 265 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[265]}"
+		elif [ $index -le $GTK2_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$GTK2_INDEX]}"
 		
-		elif [ $index -le 278 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[278]}"
+		elif [ $index -le $GDK_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$GDK_INDEX]}"
 		
-		elif [ $index -le 292 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[292]}"
+		elif [ $index -le $CAIRO_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$CAIRO_INDEX]}"
 		
-		elif [ $index -le 327 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[327]}"
+		elif [ $index -le $PANGO_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$PANGO_INDEX]}"
 		
-		elif [ $index -le 329 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[329]}"
+		elif [ $index -le $XTST_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$XTST_INDEX]}"
 		
-		elif [ $index -le 363 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[363]}"
+		elif [ $index -le $ATK_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$ATK_INDEX]}"
 		
-		elif [ $index -le 367 ]; then 
-			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[367]}"
+		elif [ $index -le $FREEGLUT_INDEX ]; then 
+			echo "$MESSAGE_INSTALL: ${HEADERS_EQUIVALENT_DEB[$FREEGLUT_INDEX]}"
 		fi
+
 }
 
 printOK(){

--- a/lamw_manager/core/installer/configure.sh
+++ b/lamw_manager/core/installer/configure.sh
@@ -511,19 +511,19 @@ systemHasLibsToBuildLazarus(){
 systemHasHeadersToBuildLazarus(){
 	local -i count=0
 	local libs
+	
 	for i in ${HEADERS[@]}; do
 		libs="$(basename $i)"
 		printf "Checking $libs"
 		if [ -e $i ]; then 
-			((count++))
 			printOK "$libs"
 		else 
 			printFail "$libs"
-			showPackageNameByIndex "$i"
+			showPackageNameByIndex "$count"
 			exit 1
 		fi
+		((count++))
 	done
-	[ $count = ${#HEADERS[@]} ]
 }
 
 

--- a/lamw_manager/core/installer/configure.sh
+++ b/lamw_manager/core/installer/configure.sh
@@ -551,8 +551,10 @@ CheckIfSystemNeedTerminalMitigation(){
 	local desktop_env="$LAMW_USER_DESKTOP_SESSION $LAMW_USER_XDG_CURRENT_DESKTOP"
 	local gnome_regex="(GNOME)"
 	local xfce_regex="(XFCE)"
+	local cinnamon_regex="(X\-CINNAMON)"
 
 	if 	[[ "$desktop_env" =~ $gnome_regex ]] ||
+		[[ "$desktop_env" =~ $cinnamon_regex ]] || 
 		[[ "$desktop_env" =~ $xfce_regex ]]; then 
 			NEED_XFCE_MITIGATION=1
 			SOFTWARES+=(xterm)

--- a/lamw_manager/docs/other-distros-info.md
+++ b/lamw_manager/docs/other-distros-info.md
@@ -19,6 +19,7 @@ Compatible Linux Distro
 +	[Fedora **GNOME**](#Fedora)
 +	[Manjaro **XFCE**](#Manjaro)
 +	[Slackware **XFCE**](#Slackware)
++	[OpenSuse **XFCE**](#opensuse-tumbleweed)
 
 
 ## Requirements ##
@@ -57,6 +58,11 @@ Manjaro
 ---
 ```bash 
 	sudo pacman -Syyu gtk2 binutils make unzip gdb xterm jq xmlstarlet wget git zenity bc --noconfirm
+```
+openSUSE Tumbleweed
+---
+```bash
+	sudo zypper install binutils wget unzip git zenity xmlstarlet gdb glibc-devel make jq  freeglut-devel libXtst-devel  pango-devel gdk-pixbuf-devel gtk2-devel libX11-devel  atkmm-devel cairo-devel gcc bc
 ```
 
 Slackware

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -5,8 +5,8 @@ This page contains information about new features and bug fixes.
 v0.5.3 - Jan 7, 2023
 --
 **Fixes**
-+	Fix fpc source code path in git (ambiguous path)
-+	Fix missing bc
++	Fixes fpc source code path in git (ambiguous path)
++	Fixes missing bc
 
 **News**
 +	Optimizes LAMW4Linux installation/update time
@@ -20,11 +20,11 @@ v0.5.2 - Dec 21, 2022
 +	Prevents lamw_manager from not installing in \~/snap and /usr/lib/lazarus folders
 
 **News**
-+	Add support to user's sudo from wheel group
-+	Add experimental support to downgrade Lazarus Project
++	Adds support to user's sudo from wheel group
++	Adds experimental support to downgrade Lazarus Project
 +	Expands templates and simplify the [*settings-editor*](https://github.com/dosza/LAMWManager-linux/blob/master/lamw_manager/core/settings-editor)
 +	*\-\-minimal* option can now be combined with *\-\-reset*, *\-\-reinstall*
-+	Add experimental functionality: allows running lamw manager on non-debian based systems
++	Added experimental functionality: allows running lamw manager on non-debian based systems
 	+	It only requires the user to install the libraries and utilities to run lamw_manager
 	+	Automatically detect missing dependencies
 +	LAMW Manager installs faster than previous versions.
@@ -41,7 +41,7 @@ v0.5.1 - Ago 18, 2022
 +	Adds support to old format of package.xml in cmdline-tools
 
 **News**
-+	Add templates in [*settings-editor*](https://github.com/dosza/LAMWManager-linux/blob/master/lamw_manager/core/settings-editor)
++	Adds templates in [*settings-editor*](https://github.com/dosza/LAMWManager-linux/blob/master/lamw_manager/core/settings-editor)
 
 
 v0.5.0 - Jun 12, 2022
@@ -50,7 +50,7 @@ v0.5.0 - Jun 12, 2022
 +	Fixes wrong ld path on try build lazarus project to linux/x86_64
 
 **News**
-+	Add new commands to LAMW4Linux Terminal, you can run directly (with auto-complete  tab)
++	Adds new commands to LAMW4Linux Terminal, you can run directly (with auto-complete  tab)
 	+	sdkmanager
 	+	advmanager
 	+	lamw_manager
@@ -59,7 +59,7 @@ v0.4.8 - Mar 8, 2022
 ---
 **Fixes**
 +	Fixes get LAMW Environment
-+	Add validation before delete *\$ANDROID_HOME*, *\$GRADLE_HOME* from \~/.bashrc
++	Adds validation before delete *\$ANDROID_HOME*, *\$GRADLE_HOME* from \~/.bashrc
 
 **News**
 +	Ubuntu 18.04 LTS is no longer officially supported!
@@ -82,9 +82,9 @@ v0.4.7 - Feb 19, 2022
 v0.4.6 - Feb 11, 2022
 ---
 **News:**
-+	Add *lazbuild* startup script on *\$LAMW4LINUX_HOME/usr/bin* with PPC_CONFIG_PATH and --pcp params
++	Adds *lazbuild* startup script on *\$LAMW4LINUX_HOME/usr/bin* with PPC_CONFIG_PATH and --pcp params
 +	Build FPC and Lazarus base on silence mode
-+	Add new command *--minimal*, to install only minimal fpc/lazarus crosscompile to Android.
++	Adds new command *--minimal*, to install only minimal fpc/lazarus crosscompile to Android.
 
 **Fixes**
 +	Remove unnecessary *[core.cross-builder](https://github.com/dosza/LAMWManager-linux/tree/e1a9311804f66f19044a1a2150d721afe1624a08/lamw_manager/core/cross-builder)* functions
@@ -174,7 +174,7 @@ v0.4.1.3 - Set 12, 2021
 v0.4.1.2 - Aug 20, 2021
 ---
 **News**
-+	Add /Update\<FppkgConfigFile\> tag (*and attributes*)  in  \~/.lamw4linux/environmentoptions.xml
++	Adds /Update\<FppkgConfigFile\> tag (*and attributes*)  in  \~/.lamw4linux/environmentoptions.xml
 
 **Fixed**
 +	Remove deprecated symbolic link: \~LAMW/lamw4linux/lamw4linux
@@ -205,7 +205,7 @@ v0.4.1 - Jul 27, 2021
 
 **Note**
 
-1.	To continue using Apache Ant (hybrid install), you must use [*LAMW Manager Setup v0.4.0.x*](https://github.com/dosza/LAMWManager-linux/raw/v0.4.0/lamw_manager/assets/lamw_manager_setup.sh) 
+1.	To continue using Apache Ant (hybrid install), you must use [*LAMW Manager Setup v0.4.0.x*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.4.0.10/lamw_manager_setup.sh) 
 
 v0.4.0.3 - Jul 28, 2021
 ---
@@ -247,8 +247,8 @@ v0.4.0 - Jun 20, 2021
 + 	Ubuntu 16.04 LTS is no longer officially supported!
 
 **Fixed:**
-+	Fix unnecessary delete fpc/lazarus sources folder to *svn cleanup*
-+	Add validation before delete files created by LAMW Manager
++	Fixes unnecessary delete fpc/lazarus sources folder to *svn cleanup*
++	Adds validation before delete files created by LAMW Manager
 
 
 v0.3.6.2 - May 6, 2021
@@ -264,7 +264,7 @@ v0.3.6.2 - May 6, 2021
 v0.3.6.1 - February 5, 2021
 ---
 **Fixed:**
-+	Add minimal built tools requeried by Gradle
++	Adds minimal build tools required by Gradle
 +	Setup android 29 libs on fpc.cfg
 
 
@@ -284,7 +284,7 @@ v0.3.5 - R1 August 6, 2020
 ---
 **Fixed:**
 +	Missing Android API's
-+	Fix: *--reset-aapis*
++	Fixes: *--reset-aapis*
 
 
 v0.3.5 - July 19, 2020
@@ -314,12 +314,12 @@ v0.3.4 - R1 - May 20, 2020
 v0.3.4 - March 10, 2020
 ---
 **News:**
-+	Add/fixs Path to FPCSourceDirectory  ~/.lamw4linux/environmentoptions.xml
++	Adds/fixs Path to FPCSourceDirectory  ~/.lamw4linux/environmentoptions.xml
 +	Optmization code on core/common-shell.sh
 	
 **Fixed:**
-+	Fix --update-lamw: cannot executable lamw4linux
-+	Fix error: detect fpc-laz
++	Fixed --update-lamw: cannot executable lamw4linux
++	Fixed error: detect fpc-laz
 +	Error: Exit without Install APT Dependencies
 +	Prevent error: install unrar packager
 	
@@ -344,7 +344,7 @@ v0.3.3 - November 26, 2019
 +	Lazarus 2.0.6
 +	Install new LAMW package: *FCL Bridges*!
 +	Introducing a new installer : *lamw_manager_setup.sh*
-+	Add (transparent) support for non-sudo admin users
++	Adds (transparent) support for non-sudo admin users
 +	Now LAMW Manager prevents **APT/dpkg** lock error
 +	Detect and uses fpc-laz to provide FPC compiler
 +	Adds JDK 11 Support for systems without JDK8
@@ -354,7 +354,7 @@ v0.3.3 - November 26, 2019
 	
 **Fixed:**
 +	Error run command : *fpcmkcfg* with *fpc-laz*
-+	Fix incompatibility with *fpc-laz* and *lazarus-project*   
++	Fixes incompatibility with *fpc-laz* and *lazarus-project*   
 		
 
 v0.3.2 - R1 - September 8, 2019
@@ -396,10 +396,10 @@ v0.3.0 - May 10, 2019
 ---
 **News:**
 +	Update FPC to 3.0.0 to 3.0.4 on Ubuntu 16.04/Linux Mint 18
-+	Add Auto Repair to fixs FPC
++	Adds Auto Repair to fixs FPC
 	
 **Fixed:**	
-+	Fix Uninstaller
-+	Fix missing ppcrossarm
++	Fixes Uninstaller
++	Fixes missing ppcrossarm
 	
 

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -4,11 +4,17 @@ This page contains information about new features and bug fixes.
 
 v0.5.3-r1 - Mar 9, 2023
 ---
+
+This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON**or **Manjaro**
+
 **Fixes**
 +	Fixes to non-debian systems
 	+	Fixes missing cairo-tee.h
 	+	Detect Cinnamon 
 	+	Fix showPackageNameByIndex ( get debian package name equivalent)
+
+**News**
++	Added OpenSuse Docs
 
 v0.5.3 - Jan 7, 2023
 --

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -2,6 +2,14 @@
 
 This page contains information about new features and bug fixes.
 
+v0.5.3-r1 - Mar 9, 2023
+---
+**Fixes**
++	Fixes to non-debian systems
+	+	Fixes missing cairo-tee.h
+	+	Detect Cinnamon 
+	+	Fix showPackageNameByIndex ( get debian package name equivalent)
+
 v0.5.3 - Jan 7, 2023
 --
 **Fixes**

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -5,7 +5,7 @@ This page contains information about new features and bug fixes.
 v0.5.3-r1 - Mar 9, 2023
 ---
 
-This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON**or **Manjaro**
+This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON** or **Manjaro**
 
 **Fixes**
 +	Fixes to non-debian systems


### PR DESCRIPTION
v0.5.3-r1 - Mar 9, 2023
---

This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON** or **Manjaro**

**Fixes**
+	Fixes to non-debian systems
	+	Fixes missing cairo-tee.h
	+	Detect Cinnamon 
	+	Fix showPackageNameByIndex ( get debian package name equivalent)

**News**
+	Added OpenSuse Docs
