### PR TITLE
v0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.5.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053-r1---mar-9-2023) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/master/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.5.4-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v054---may-13-2023) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.4/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/master/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -60,7 +60,7 @@ LAMW Manager install the following [dependencies] tools:
 Getting Started!!
 ---
 **How to use LAMW Manager:**
-+	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.3/lamw_manager_setup.sh)
++	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.5.4/lamw_manager_setup.sh)
 +	Go to download directory and right click *Open in Terminal*
 +	Run command : *bash lamw_manager_setup.sh*¹
 
@@ -98,11 +98,11 @@ Recommended:
 
 Release Notes:
 ---
-For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v053-r1---mar-9-2023)
+For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/release_notes.md#v054---may-13-2023)
 
 Congratulations!!
 ---
 You are now a Lazarus for Android developer!</br>[Building Android application with **LAMW** is **RAD**!](https://drive.google.com/open?id=1CeDDpuDfRwYrKpN7VHbossH6GfZUfqjm)
 
-For more info read [**LAMW Manager v0.5.3 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/man.md)
+For more info read [**LAMW Manager v0.5.4 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.5.x/lamw_manager/docs/man.md)
 

--- a/lamw_manager/assets/build-lamw-setup
+++ b/lamw_manager/assets/build-lamw-setup
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: This script generates compiles LAMW Manager source code into an executable installer.
 #Note: This script requires makeself, read more in https://makeself.io/
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/cross-builder/cross-builder.sh
+++ b/lamw_manager/core/cross-builder/cross-builder.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description:The "cross-builder.sh" is part of the core of LAMW Manager.  This script contains crosscompile compiler generation routines for ARMv7 / AARCH64- Android
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.init_lamw_manager.sh
+++ b/lamw_manager/core/headers/.init_lamw_manager.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: The ".init_lamw_manager.sh" is part of the core of LAMW Manager. This script check conditions to init LAMW Manager
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
+#Version: 0.5.4
 #Description: This script contains routines for completing LAMW Manager arguments.
 #Ref:https://www.vivaolinux.com.br/dica/Shell-script-autocompletion-Como-implementar
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/headers/lamw4linux_env.sh
+++ b/lamw_manager/core/headers/lamw4linux_env.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 LAMW_IDE_HOME_CFG="$LAMW_USER_HOME/.lamw4linux"

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -128,7 +128,7 @@ FPC_DEB="fpc-laz_${FPC_DEB_VERSION}_amd64.deb"
 LAMW_FRAMEWORK_HOME="$ROOT_LAMW/lazandroidmodulewizard"
 
 LIBS_ANDROID="libx11-dev libgtk2.0-dev libgdk-pixbuf2.0-dev libcairo2-dev libpango1.0-dev libxtst-dev libatk1.0-dev freeglut3 freeglut3-dev "
-PROG_TOOLS="git make build-essential zip unzip gdb wget jq xmlstarlet psmisc zenity bc"
+PROG_TOOLS="git make gcc libc6-dev zip unzip gdb wget jq xmlstarlet psmisc zenity bc"
 
 FPC_TRUNK_SOURCE_PATH="$LAMW4LINUX_HOME/usr/share/fpcsrc"
 

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 
@@ -11,7 +11,7 @@
 #										Section Version Variables
 #--------------------------------------------------------------------------------------------------
 
-LAMW_INSTALL_VERSION="0.5.3"
+LAMW_INSTALL_VERSION="0.5.4"
 JDK_VERSION=11
 ANT_VERSION_STABLE='1.10.11'
 CMD_SDK_TOOLS_VERSION="9123335"
@@ -53,12 +53,12 @@ OLD_LAZARUS_STABLE_VERSION=(
 )
 
 OLD_LAMW_INSTALL_VERSION=(
-	0.5.{2..0}
+	0.5.{3..0}
 	0.4.{8..4}
 	0.4.3{.1,}
 	0.4.2{.{2..1},}
 	0.4.1{.{6..1},}
-	0.4.0{.{11..1},}
+	0.4.0{.{12..1},}
 	0.3.6{.{2,1},}
 	0.3.{5,4}{r1,}
 	"0.3.3r2"

--- a/lamw_manager/core/installer/distro-overrides.sh
+++ b/lamw_manager/core/installer/distro-overrides.sh
@@ -19,5 +19,5 @@ installDebianDependencies(){
 	[ $IS_DEBIAN = 0 ] && return 
 	getCurrentDebianFrontend
 	checkNeedXfceMitigation
-	AptInstall $LIBS_ANDROID $PROG_TOOLS
+	AptInstall $LIBS_ANDROID $PROG_TOOLS --no-install-recommends
 }

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -16,11 +16,12 @@ isMultiCoreProcessor(){
 #This function issues slow execution warnings on single computers (or VMs).
 singleCoreWarning(){
 	isMultiCoreProcessor && return 
-	echo "${VERMELHO}Warning:${NORMAL} running the LAMW Manager on a ${NEGRITO}single core processor${NORMAL}, this can make processing ${NEGRITO}very slow${NORMAL}!"
-	if  systemd-detect-virt -q &>/dev/null ; then 
-		echo "${VERMELHO}Warning:${NORMAL} running in a ${NEGRITO}VM${NORMAL}, check the settings to enable using ${NEGRITO}more cores${NORMAL}!"
+	printf "\n%s\n" "${VERMELHO}Warning:${NORMAL} running the LAMW Manager on a ${NEGRITO}single core processor${NORMAL}, this can make processing ${NEGRITO}very slow${NORMAL}!"
+	sleep 1
+	if !  systemd-detect-virt -q &>/dev/null ; then 
+		printf "%s\n\n" "${VERMELHO}Warning:${NORMAL} running in a ${NEGRITO}VM${NORMAL}, check the settings to enable using ${NEGRITO}more cores${NORMAL}!"
+		sleep 1.5
 	fi
-	sleep 1.5
 }
 
 checkOldCmdlineTools(){

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -6,8 +6,21 @@
 #Date: 01/05/2023
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
-#set Remove Gradle from different
 
+#this function return true if computer is multicore processor
+isMultiCoreProcessor(){
+	local dualcore=2
+	[  $CPU_COUNT -ge $dualcore ]
+}
+
+#This function issues slow execution warnings on single computers (or VMs).
+singleCoreWarning(){
+	isMultiCoreProcessor && return 
+	echo "${VERMELHO}:Warning:${NORMAL} running the LAMW Manager on a single core processor, this can make processing very slow!"
+	if  systemd-detect-virt -q &>/dev/null ; then 
+		echo "${VERMELHO}Warning${NORMAL}: running in a VM, check the settings to enable using more cores!"
+	fi
+}
 
 checkOldCmdlineTools(){
 	local ret=1
@@ -710,6 +723,7 @@ installFixLp(){
 mainInstall(){
 	getFiller
 	checkLAMWManagerVersion > /dev/null
+	singleCoreWarning
 	initROOT_LAMW
 	installSystemDependencies
 	setLAMWDeps

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -680,7 +680,7 @@ requestFixlpSnapshot(){
 	export FIXLP_URL="https://sourceforge.net/code-snapshots/svn/l/la/lazarus-ccr/svn/lazarus-ccr-svn-r${FIXLP_VERSION}-applications-fixlp.zip"
 	export FIXLP_ZIP="lazarus-ccr-svn-r${FIXLP_VERSION}-applications-fixlp.zip"
 
-	if ! wget  -O- --post-data "_session_id_=${_sesion_id_}&path=/applications/fixlp" 'https://sourceforge.net/p/lazarus-ccr/svn/HEAD/tarball' >/dev/null;  then 
+	if ! wget  -qO- --post-data "_session_id_=${_sesion_id_}&path=/applications/fixlp" 'https://sourceforge.net/p/lazarus-ccr/svn/HEAD/tarball' >/dev/null;  then 
 		USE_FIXLP=1
 	fi
 

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -16,9 +16,9 @@ isMultiCoreProcessor(){
 #This function issues slow execution warnings on single computers (or VMs).
 singleCoreWarning(){
 	isMultiCoreProcessor && return 
-	echo "${VERMELHO}:Warning:${NORMAL} running the LAMW Manager on a single core processor, this can make processing very slow!"
+	echo "${VERMELHO}Warning:${NORMAL} running the LAMW Manager on a ${NEGRITO}single core processor${NORMAL}, this can make processing ${NEGRITO}very slow${NORMAL}!"
 	if  systemd-detect-virt -q &>/dev/null ; then 
-		echo "${VERMELHO}Warning${NORMAL}: running in a VM, check the settings to enable using more cores!"
+		echo "${VERMELHO}Warning:${NORMAL} running in a ${NEGRITO}VM${NORMAL}, check the settings to enable using ${NEGRITO}more cores${NORMAL}!"
 	fi
 }
 

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -20,6 +20,7 @@ singleCoreWarning(){
 	if  systemd-detect-virt -q &>/dev/null ; then 
 		echo "${VERMELHO}Warning:${NORMAL} running in a ${NEGRITO}VM${NORMAL}, check the settings to enable using ${NEGRITO}more cores${NORMAL}!"
 	fi
+	sleep 1.5
 }
 
 checkOldCmdlineTools(){

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -21,6 +21,7 @@ checkOldCmdlineTools(){
 	return $ret
 } 
 
+#set old Gradle from $LAMW_INSTALL_LOG
 setOldGradleVersion(){
 	[ ! -e "$LAMW_INSTALL_LOG" ] && return 
 

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -18,7 +18,7 @@ singleCoreWarning(){
 	isMultiCoreProcessor && return 
 	printf "\n%s\n" "${VERMELHO}Warning:${NORMAL} running the LAMW Manager on a ${NEGRITO}single core processor${NORMAL}, this can make processing ${NEGRITO}very slow${NORMAL}!"
 	sleep 1
-	if !  systemd-detect-virt -q &>/dev/null ; then 
+	if  systemd-detect-virt -q &>/dev/null ; then 
 		printf "%s\n\n" "${VERMELHO}Warning:${NORMAL} running in a ${NEGRITO}VM${NORMAL}, check the settings to enable using ${NEGRITO}more cores${NORMAL}!"
 		sleep 1.5
 	fi

--- a/lamw_manager/core/lamw-mgr.sh
+++ b/lamw_manager/core/lamw-mgr.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: The "lamw-install.sh" is part of the core of LAMW Manager. This script configures the development environment for LAMW
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (mater-alma)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description: The "lamw-manager-settings-editor.sh" is part of the core of LAMW Manager. Responsible for managing LAMW Manager / LAMW configuration files..
 #-----------------------------------------------------------------------f--------------------------#
 #this function builds initial struct directory of LAMW env Development !

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -183,13 +183,15 @@ SystemTerminalMitigation(){
 	local xterm_path=$(which xterm)
 	local desktop_env="$LAMW_USER_DESKTOP_SESSION $LAMW_USER_XDG_CURRENT_DESKTOP"
 	local gnome_regex="(GNOME)"
+	local cinnamon_regex="(X\-CINNAMON)"
 	local xfce_regex="(XFCE)"
 	local lamw4linux_bin="$LAMW4LINUX_HOME/usr/bin"
 	local lamw4linux_gnome_terminal="$lamw4linux_bin/gnome-terminal"
 	local lamw4linux_xfce_terminal="$lamw4linux_bin/xfce4-terminal"
 	
-	# is a gnome system 
-	if [[ "$desktop_env" =~ $gnome_regex ]]; then
+	# is a gnome system or cinnamon
+	if 	[[ "$desktop_env" =~ $gnome_regex ]] ||
+		[[ "$desktop_env" =~ $cinnamon_regex ]]; then
 		
 		[ -e "$lamw4linux_gnome_terminal" ] && rm $lamw4linux_gnome_terminal
 		ln -s $xterm_path "$lamw4linux_gnome_terminal"

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -3,7 +3,7 @@
 updateBuildDotGradle(){
 	
 	[ "${FUNCNAME[1]}"	!= 'cacheGradle' ] && return 1
-
+	local max_cpu="$(grep -c ^processor /proc/cpuinfo)"
 	local current_compile_sdk="$(grep compileSdkVersion $PWD/build.gradle | sed 's/^[[:blank:]]//g')"
 	local current_target_sdk="$(grep targetSdkVersion $PWD/build.gradle | sed 's/^[[:blank:]]//g')"
 	local current_gradle_plugin=$( grep 'com\.android\.tools.build:gradle' $PWD/build.gradle )
@@ -28,6 +28,13 @@ updateBuildDotGradle(){
 	if grep androidx build.gradle -i -q ;then 
 		echo 'android.useAndroidX=true' >> gradle.properties
 		echo 'android.enableJetifier=true' >>gradle.properties
+	fi
+
+	if ! grep  "^org\.gradle\.workers\.max" local.properties; then
+		echo 'org.gradle.configureondemand=true' >> local.properties
+		echo 'org.gradle.daemon=true'	>> local.properties
+		echo 'org.gradle.parallel=true' >> local.properties
+		echo "org.gradle.workers.max=$max_cpu"  >>local.properties
 	fi
 }
 

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -61,7 +61,7 @@ cacheGradle(){
 		updateBuildDotGradle
 		echo "sdk.dir=$ANDROID_SDK_ROOT"> local.properties
 		echo "ndk.dir=$ANDROID_SDK_ROOT/ndk-bundle" >> local.properties
-		gradle clean build --info
+		gradle clean build
 
 	done
 

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -3,7 +3,6 @@
 updateBuildDotGradle(){
 	
 	[ "${FUNCNAME[1]}"	!= 'cacheGradle' ] && return 1
-	local max_cpu="$(grep -c ^processor /proc/cpuinfo)"
 	local current_compile_sdk="$(grep compileSdkVersion $PWD/build.gradle | sed 's/^[[:blank:]]//g')"
 	local current_target_sdk="$(grep targetSdkVersion $PWD/build.gradle | sed 's/^[[:blank:]]//g')"
 	local current_gradle_plugin=$( grep 'com\.android\.tools.build:gradle' $PWD/build.gradle )
@@ -30,12 +29,21 @@ updateBuildDotGradle(){
 		echo 'android.enableJetifier=true' >>gradle.properties
 	fi
 
-	if ! grep  "^org\.gradle\.workers\.max" local.properties; then
-		echo 'org.gradle.configureondemand=true' >> local.properties
-		echo 'org.gradle.daemon=true'	>> local.properties
-		echo 'org.gradle.parallel=true' >> local.properties
-		echo "org.gradle.workers.max=$max_cpu"  >>local.properties
-	fi
+}
+
+saveLocalDotProperties(){
+	[ "${FUNCNAME[1]}"	!= 'cacheGradle' ] && return 1
+
+	local max_cpu="$(grep -c ^processor /proc/cpuinfo)"
+	echo "sdk.dir=$ANDROID_SDK_ROOT"> local.properties
+	echo "ndk.dir=$ANDROID_SDK_ROOT/ndk-bundle" >> local.properties
+	echo 'org.gradle.configureondemand=true' >> local.properties
+	echo 'org.gradle.daemon=true'	>> local.properties
+	echo 'org.gradle.parallel=true' >> local.properties
+	echo "org.gradle.workers.max=$max_cpu"  >>local.properties
+	
+
+	
 }
 
 cacheGradle(){
@@ -59,8 +67,7 @@ cacheGradle(){
 	for demo in ${lamw_tmp_demos[@]};do
 		cd "$demo"
 		updateBuildDotGradle
-		echo "sdk.dir=$ANDROID_SDK_ROOT"> local.properties
-		echo "ndk.dir=$ANDROID_SDK_ROOT/ndk-bundle" >> local.properties
+		saveLocalDotProperties
 		gradle clean build
 
 	done

--- a/lamw_manager/docs/other-distros-info.md
+++ b/lamw_manager/docs/other-distros-info.md
@@ -51,7 +51,7 @@ After installing the dependencies on the system, you will be able to run lamw_ma
 Fedora
 ---
 ```bash
-	sudo dnf install libX11-devel.x86_64 libX11.x86_64 gdk-pixbuf2.x86_64 gdk-pixbuf2-devel.x86_64 librsvg2.x86_64 pango-devel.x86_64 freeglut-devel.x86_64 libXtst-devel.x86_64 atk-devel.x86_64 gtk2-devel.x86_64 wget.x86_64 git.x86_64 xterm make.x86_64  gdb.x86_64 zip.x86_64 unzip.x86_64 jq.x86_64 xmlstarlet.x86_64 bc.x86_64 -y
+	sudo dnf install libX11-devel.x86_64 libX11.x86_64 gdk-pixbuf2.x86_64 gdk-pixbuf2-devel.x86_64 librsvg2.x86_64 pango-devel.x86_64 freeglut-devel.x86_64 libXtst-devel.x86_64 atk-devel.x86_64 gtk2-devel.x86_64 wget.x86_64 git.x86_64 xterm make.x86_64  gdb.x86_64 zip.x86_64 unzip.x86_64 jq.x86_64 xmlstarlet.x86_64 bc.x86_64 binutils.x86_64 gcc.x86_64 -y
 ```
 
 Manjaro

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -7,9 +7,12 @@ v0.5.4 - May 13, 2023
 
 **Fixes**
 +	Fixes getFixLp
++	Fixes to non-debian systems
+	+	Fixes Gnome Terminal mitigation
 
 **News**
-+	Adds slow running warnings on single core machines (or VMs)	
++	Adds slow running warnings on single core machines (or VMs)
++	Remove unnecessary APT dependencies
 
 v0.5.3-r1 - Mar 9, 2023
 ---

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -2,6 +2,15 @@
 
 This page contains information about new features and bug fixes.
 
+v0.5.4 - May 13, 2023
+---
+
+**Fixes**
++	Fixes getFixLp
+
+**News**
++	Adds slow running warnings on single core machines (or VMs)	
+
 v0.5.3-r1 - Mar 9, 2023
 ---
 

--- a/lamw_manager/lamw_manager
+++ b/lamw_manager/lamw_manager
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.5.3
-#Date: 01/05/2023
+#Version: 0.5.4
+#Date: 05/13/2023
 #Description:The "lamw_manager" is part of the core of LAMW Manager. This script is a wrapper for "core/lamw-instal.sh"
 #-------------------------------------------------------------------------------------------------#
 


### PR DESCRIPTION
v0.5.4 - May 13, 2023
---

**Fixes**
+	Fixes getFixLp
+	Fixes to non-debian systems
	+	Fixes Gnome Terminal mitigation

**News**
+	Adds slow running warnings on single core machines (or VMs)
+	Remove unnecessary APT dependencies
