### PR TITLE
v0.6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install makeself
+        run: |
+          sudo apt-get update
+          sudo apt-get install makeself
+            - name: Run script from repository root
+      
+      - name: Run script from repository root
+        run: |
+          ls -la 
+
       - name: Run tests
         run: ./lamw_manager/tests/run-tests
 


### PR DESCRIPTION
- prepare v0.6.2
- add support to check lamw_manager updates from lamw4linux-terminal
- split update-manager of lamw4linux-terminal
- add breakline
- fix trimVersion
- fixes get version number
- test $0 is not bash
- add update-lamw-manager-tests.sh
- add  test-compareVersion
- ignore load modules err messages
- add test-checkLAMWManageUpdates
- fixes erros case
- add test-get-lamw-manager-updates
- fixes settings-editor-tests.sh
- prepare v0.6.2 docs
- update releases_notes.md
- remove breaklines unecessary
- rename functions using low case pattern
- add user notification test
- supress creation .update-lamw-manager temp file
- enable update message
- add help
- add usage test
- add github workflow
- add lamw_manager_setup build
- rename workflow file
- fixes workflow
