### PR TITLE
v0.6.x test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,11 @@ jobs:
           for version in $(git log --pretty=format:'%s');do
           if [[ "$version" =~ $version_regex ]];then
           echo $version
+          fi
+          done
+          for version in $(git log --pretty=format:'%s');do
+          if [[ "$version" =~ $version_regex ]];then
+          echo $version
           break
           fi
           done


### PR DESCRIPTION
- print version on workflow
- v0.6.2-r2
- v0.6.2-r3
- v0.6.2-r3
- fixes get tag
- try get version
- try get version with for
- use bash regex support
- try debug version
