### PR TITLE
v0.6.2-fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,20 +54,8 @@ jobs:
       - name: Get tag
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
-          git checkout v0.6.x
-          git pull
-          version_regex="(^v[0-9]\.[0-9]\.[0-9])"
-          for version in $(git log --pretty=format:'%s');do
-          if [[ "$version" =~ $version_regex ]];then
-          echo $version
-          fi
-          done
-          for version in $(git log --pretty=format:'%s');do
-          if [[ "$version" =~ $version_regex ]];then
-          echo $version
-          break
-          fi
-          done
+          headers_file=~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/core/headers/lamw_headers
+          version=$(grep "^LAMW_INSTALL_VERSION=" $headers_file  | awk-F= '{ print $2 }' | sed 's/"//g')
           echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release


### PR DESCRIPTION
- print version on workflow
- v0.6.2-r2
- v0.6.2-r3
- v0.6.2-r3
- fixes get tag
- try get version
- try get version with for
- use bash regex support
- try debug version
- try get version from lamw_headers
