### PR TITLE
v0.6.2-build-setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build-and-release
 
     env:
-      LAMW_MGR_TOKEN: ${{ secrets.LAMW_MGR_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN}}
 
     steps:
       - name: Checkout code
@@ -51,7 +51,7 @@ jobs:
 
       - name: Set up GitHub CLI
         run: |
-          echo "${{ secrets.LAMW_MGR_TOKEN }}" | gh auth login --with-token
+          echo "${{ secrets.GH_TOKEN }}" | gh auth login --with-token
 
       - name: Set up Git
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build-and-release
 
     env:
-      GH_TOKEN: ${{ secrets.LAMW_MGR_TOKEN}}
+      GH_TOKEN: ${{ secrets.LAMW_MGR_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -51,7 +51,7 @@ jobs:
 
       - name: Set up GitHub CLI
         run: |
-          echo "${{ secrets.LAMW_MGR_TOKEN} }}" | gh auth login --with-token
+          echo "${{ secrets.LAMW_MGR_TOKEN }}" | gh auth login --with-token
 
       - name: Set up Git
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Get tag
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
+          git checkout v0.6.x
+          git pull
           git log --pretty=format:'%s' | grep '^v[0-9]\.[0-9]\.[0-9]+' -m1 > ~/lamw-tag.txt
 
       - name: Create tag and release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -56,7 +59,7 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           headers_file=~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/core/headers/lamw_headers
           version=$(grep "^LAMW_INSTALL_VERSION" $headers_file  | awk -F= '{ print $2 }' | sed 's/"//g')
-          echo "$version" > ~/lamw-tag.txt
+          echo "v$version" > ~/lamw-tag.txt
 
       - name: Create tag and release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Get tag
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
-          git log --pretty=format:'%s' | grep -o -E '^v[0-9]+\.[0-9]+\.[0-9]+' -m1> ~/lamw-tag.txt
-          cat ~/lamw-tag
+          git log --pretty=format:'%s' | grep '^v[0-9]\.[0-9]\.[0-9]+' -m1 > ~/lamw-tag.txt
+          cat ~/lamw-tag.txt
 
       - name: Create tag and release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build-and-release
 
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.LAMW_MGR_TOKEN}}
 
     steps:
       - name: Checkout code
@@ -51,7 +51,7 @@ jobs:
 
       - name: Set up GitHub CLI
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          echo "${{ secrets.LAMW_MGR_TOKEN} }}" | gh auth login --with-token
 
       - name: Set up Git
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           headers_file=~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/core/headers/lamw_headers
-          version=$(grep "^LAMW_INSTALL_VERSION" $headers_file )
+          version=$(grep "^LAMW_INSTALL_VERSION" $headers_file  | awk -F= '{ print $2 }' | sed 's/"//g')
           echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,6 @@ jobs:
     needs: build-and-release
 
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN}}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Set up GitHub CLI
+          run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
       - name: Set up Git
         run: |
           git config --global user.email "actions@github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,8 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           git checkout v0.6.x
           git pull
-          git log --pretty=format:'%s' | grep "^v[0-9]\.[0-9]\.[0-9]+" -m1 > ~/lamw-tag.txt
+          version=$(git log --pretty=format:"%s" | grep "^v[0-9]\.[0-9]\.[0-9]+" -m1) 
+          echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           git log --pretty=format:'%s' | grep '^v[0-9]\.[0-9]\.[0-9]+' -m1 > ~/lamw-tag.txt
-          cat ~/lamw-tag.txt
 
       - name: Create tag and release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: build-and-release
-
-    env:
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,13 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           git checkout v0.6.x
           git pull
-          for version in $(git log --pretty=format:'%s'); do if echo $version |  grep -o -E ^v'[0-9]+\.[0-9]+\.[0-9]+'; then break; fi; done
+          version_regex="(^v[0-9]\.[0-9]\.[0-9])"
+          for version in $(git log --pretty=format:'%s');do
+          if [[ "$version" =~ $version_regex ]];then
+          echo $version
+          break
+          fi
+          done
           echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build-and-release
 
     env:
-      GH_TOKEN: ${{ secrets.LAMW_MGR_TOKEN }}
+      LAMW_MGR_TOKEN: ${{ secrets.LAMW_MGR_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,11 @@ jobs:
           for version in $(git log --pretty=format:'%s');do
           if [[ "$version" =~ $version_regex ]];then
           echo $version
+          fi
+          done
+          for version in $(git log --pretty=format:'%s');do
+          if [[ "$version" =~ $version_regex ]];then
+          echo $version
           break
           fi
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,20 +54,8 @@ jobs:
       - name: Get tag
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
-          git checkout v0.6.x
-          git pull
-          version_regex="(^v[0-9]\.[0-9]\.[0-9])"
-          for version in $(git log --pretty=format:'%s');do
-          if [[ "$version" =~ $version_regex ]];then
-          echo $version
-          fi
-          done
-          for version in $(git log --pretty=format:'%s');do
-          if [[ "$version" =~ $version_regex ]];then
-          echo $version
-          break
-          fi
-          done
+          headers_file=~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/core/headers/lamw_headers
+          version=$(grep "^LAMW_INSTALL_VERSION" $headers_file )
           echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
     branches:
-      - base-state
+      - v0.6.x
 
   release:
     types:
@@ -51,11 +51,16 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Create tag and release
+      - name: Get tag
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux
-          version=$(git log --pretty=format:'%s' | grep -o -E '^v[0-9]+\.[0-9]+\.[0-9]+' -m1)
-          echo "version  = $version"
+          git log --pretty=format:'%s' | grep -o -E '^v[0-9]+\.[0-9]+\.[0-9]+' -m1> ~/lamw-tag.txt
+          cat ~/lamw-tag
+
+      - name: Create tag and release
+        run: |
+          version=$(<~/lamw-tag.txt)
+          echo $version
           git tag -a $version -m "Release $version"
           git push origin $version
           gh release create $version -t "Release $version" -n "Release notes for $version" /tmp/lamw_manager_setup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
 
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -45,12 +42,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-release
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Set up GitHub CLI
-          run: |
+        run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Set up Git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           git checkout v0.6.x
           git pull
-          version=$(git log --pretty=format:"%s" | grep "^v[0-9]\.[0-9]\.[0-9]+" -m1) 
+          for version in $(git log --pretty=format:'%s'); do if echo $version |  grep -o -E ^v'[0-9]+\.[0-9]+\.[0-9]+'; then break; fi; done
           echo "$version" > ~/lamw-tag.txt
 
       - name: Create tag and release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux
           git checkout v0.6.x
           git pull
-          git log --pretty=format:'%s' | grep '^v[0-9]\.[0-9]\.[0-9]+' -m1 > ~/lamw-tag.txt
+          git log --pretty=format:'%s' | grep "^v[0-9]\.[0-9]\.[0-9]+" -m1 > ~/lamw-tag.txt
 
       - name: Create tag and release
         run: |


### PR DESCRIPTION
- print version on workflow
- v0.6.2-r2
- v0.6.2-r3
- v0.6.2-r3
- fixes get tag
- try get version
- try get version with for
- use bash regex support
- try debug version
- try get version from lamw_headers
