### PR TITLE
test v0.6.3 ci/cd 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Build setup
         run: |
+          sudo apt-get update
+          sudo apt-get install makeself shunit2 xmlstarlet jq
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           bash -x ./build-lamw-setup
 


### PR DESCRIPTION
- fix missing --avdmanager completation
- replace for (loop) to arrayMap
- add desktop session protection
- rename setForbiddenCommand to setDesktopSessionReplaceProtection
- minor fixes in setDesktopSessionReplaceProtection
- check if pkexec is exists in $PATH
- get releases- in ci/cd
- rename tests folder
- prepare v0.6.3
- update docs to v0.6.3
- test ci/cd
- fix missing /tmp/lamw_manager_setup.sh
- debug in ci/cd ls  ~
- move build to create-and-release
- adjusts ci/cd
- fixes missing makeself
