### PR TITLE
v0.6.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI-CD
 
 on:
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
     branches:
-      - v0.6.x-test
+      - base-state
 
   release:
     types:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install makeself shunit2 xmlstarlet jq
-      
-      - name: Run script from repository root
-        run: |
-          cd ~/work/LAMWManager-linux/LAMWManager-linux
-          ls
 
       - name: Run tests
-        run: bash ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/tests/run_tests
+        run: |
+          cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/tests
+          bash ./run_tests
+
 
   create-release:
     runs-on: ubuntu-latest
     needs: build-and-release
     environment: GH_TOKEN
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -58,10 +56,10 @@ jobs:
           version=$(grep "^LAMW_INSTALL_VERSION" $headers_file  | awk -F= '{ print $2 }' | sed 's/"//g')
           echo "v$version" > ~/lamw-tag.txt
 
-       - name: Build setup
+      - name: Build setup
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
-          bash -x ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets/build-lamw-setup
+          bash -x ./build-lamw-setup
 
       - name: Create tag and release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           bash -x ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets/build-lamw-setup
           cp /tmp/lamw_manager_setup.sh ~/lamw_manager_setup.sh
+          ls ~
 
   create-release:
     runs-on: ubuntu-latest
@@ -70,6 +71,7 @@ jobs:
           version=$(<~/lamw-tag.txt)
           releases_notes_str="$(bash get-releases-notes.sh)"
           echo $version
+          ls ~
           git tag -a $version -m "Release $version"
           git push origin $version
           gh release create $version -t "$version" -n "$releases_notes_str" ~/lamw_manager_setup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI/CD
 
 on:
-  pull_request:
+  push:
     types:
       - closed
 
@@ -41,6 +41,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: build-and-release
+    environment: GH_TOKEN
     
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: CI/CD
 
 on:
-  push:
+  pull_request:
     types:
       - closed
 
     branches:
-      - v0.6.x
+      - v0.6.x-test
 
   release:
     types:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Run tests
         run: bash ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/tests/run_tests
 
-      - name: Build setup
-        run: |
-          cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
-          bash -x ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets/build-lamw-setup
-          cp /tmp/lamw_manager_setup.sh ~/lamw_manager_setup.sh
-          ls ~
-
   create-release:
     runs-on: ubuntu-latest
     needs: build-and-release
@@ -65,13 +58,17 @@ jobs:
           version=$(grep "^LAMW_INSTALL_VERSION" $headers_file  | awk -F= '{ print $2 }' | sed 's/"//g')
           echo "v$version" > ~/lamw-tag.txt
 
+       - name: Build setup
+        run: |
+          cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
+          bash -x ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets/build-lamw-setup
+
       - name: Create tag and release
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           version=$(<~/lamw-tag.txt)
           releases_notes_str="$(bash get-releases-notes.sh)"
           echo $version
-          ls ~
           git tag -a $version -m "Release $version"
           git push origin $version
-          gh release create $version -t "$version" -n "$releases_notes_str" ~/lamw_manager_setup.sh
+          gh release create $version -t "$version" -n "$releases_notes_str" /tmp/lamw_manager_setup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Build setup
         run: |
+          sudo apt-get update
+          sudo apt-get install makeself shunit2 xmlstarlet jq
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           bash -x ./build-lamw-setup
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
       - created
 
 jobs:
-  build-and-release:
+  run-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: build-and-release
+    needs: run-tests
     environment: GH_TOKEN
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,10 @@ jobs:
 
       - name: Create tag and release
         run: |
+          cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           version=$(<~/lamw-tag.txt)
+          releases_notes_str="$(bash get-releases-notes.sh)"
           echo $version
           git tag -a $version -m "Release $version"
           git push origin $version
-          gh release create $version -t "Release $version" -n "Release notes for $version" /tmp/lamw_manager_setup.sh
+          gh release create $version -t "$version" -n "$releases_notes_str" /tmp/lamw_manager_setup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           cd ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets
           bash -x ~/work/LAMWManager-linux/LAMWManager-linux/lamw_manager/assets/build-lamw-setup
+          cp /tmp/lamw_manager_setup.sh ~/lamw_manager_setup.sh
 
   create-release:
     runs-on: ubuntu-latest
@@ -71,4 +72,4 @@ jobs:
           echo $version
           git tag -a $version -m "Release $version"
           git push origin $version
-          gh release create $version -t "$version" -n "$releases_notes_str" /tmp/lamw_manager_setup.sh
+          gh release create $version -t "$version" -n "$releases_notes_str" ~/lamw_manager_setup.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/CI-CD)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.6.2-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v062---jan-28-2024) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.2/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024) [![Build-status](https://img.shields.io/badge/build-stable-brightgreen)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -58,7 +58,7 @@ LAMW Manager install the following [dependencies] tools:
 Getting Started!!
 ---
 **How to use LAMW Manager:**
-+	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.2/lamw_manager_setup.sh)
++	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh)
 +	Go to download directory and right click *Open in Terminal*
 +	Run command : *bash lamw_manager_setup.sh*¹
 
@@ -94,11 +94,11 @@ Recommended:
 
 Release Notes:
 ---
-For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v062---jan-28-2024)
+For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024)
 
 Congratulations!!
 ---
 You are now a Lazarus for Android developer!</br>[Building Android application with **LAMW** is **RAD**!](https://drive.google.com/open?id=1CeDDpuDfRwYrKpN7VHbossH6GfZUfqjm)
 
-For more info read [**LAMW Manager v0.6.2 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
+For more info read [**LAMW Manager v0.6.3 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
 

--- a/lamw_manager/assets/build-lamw-setup
+++ b/lamw_manager/assets/build-lamw-setup
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: This script generates compiles LAMW Manager source code into an executable installer.
 #Note: This script requires makeself, read more in https://makeself.io/
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/assets/get-releases-notes.sh
+++ b/lamw_manager/assets/get-releases-notes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+
+source "../core/headers/common-shell.sh"
+
+OLDIFS=$IFS 
+IFS="
+"
+RELEASES_NOTES_PATH=$(realpath ../$(dirname $0))/docs/release_notes.md
+RELEASES_NOTES_STREAM=($(<$RELEASES_NOTES_PATH))
+RELEASES_NOTES_STREAM_F=()
+HEADERS_PATH=$(realpath ../$(dirname $0))/core/headers/lamw_headers
+
+VERSION=$(
+	grep "^LAMW_INSTALL_VERSION" $HEADERS_PATH  | 
+	awk -F= '{ print $2 }' | sed 's/"//g'
+)
+
+INDEX_MATCH_V=0
+INDEX_END=0
+VERSION_REGEX="$(GenerateScapesStr "$VERSION")"
+
+arrayMap  RELEASES_NOTES_STREAM line index '
+	if [[ "$line" =~ $VERSION_REGEX ]]; then
+		INDEX_MATCH_V=$index
+		break
+	fi'
+
+RELEASES_NOTES_STREAM=(${RELEASES_NOTES_STREAM[@]:$INDEX_MATCH_V})
+arrayMap  RELEASES_NOTES_STREAM line index '
+	if [[ "$line" =~ "---" ]] && [ $index -gt $INDEX_MATCH_V ]; then
+		INDEX_END=$index
+		let INDEX_END-=1
+		break
+	fi'
+
+arraySlice RELEASES_NOTES_STREAM 0 $INDEX_END RELEASES_NOTES_STREAM_F
+
+arrayToString RELEASES_NOTES_STREAM_F

--- a/lamw_manager/core/cross-builder/cross-builder.sh
+++ b/lamw_manager/core/cross-builder/cross-builder.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description:The "cross-builder.sh" is part of the core of LAMW Manager.  This script contains crosscompile compiler generation routines for ARMv7 / AARCH64- Android
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.init_lamw_manager.sh
+++ b/lamw_manager/core/headers/.init_lamw_manager.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: The ".init_lamw_manager.sh" is part of the core of LAMW Manager. This script check conditions to init LAMW Manager
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
+#Version: 0.6.3
 #Description: This script contains routines for completing LAMW Manager arguments.
 #Ref:https://www.vivaolinux.com.br/dica/Shell-script-autocompletion-Como-implementar
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -36,7 +36,7 @@ _lamw_manager() {
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="--help  --minimal --port --reinstall --reset --reset-aapis --sdkmanager  --server --update-lamw  --use_proxy"
+	opts="--help  --minimal --port --reinstall --reset --reset-aapis --sdkmanager --avdmanager --server --update-lamw  --use_proxy"
 
 	if [[ ${cur} == -* ]] ; then
 		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/lamw_manager/core/headers/admin-parser.sh
+++ b/lamw_manager/core/headers/admin-parser.sh
@@ -139,5 +139,5 @@ RunAsPolkit(){
 
 isSupportedPolkit(){
 	local error_msg="${VERMELHO}Fatal error:${NORMAL} Cannot run on tty terminal!!"
-	tty | grep 'pts/[0-9]'>/dev/null
+	tty | grep 'pts/[0-9]'>/dev/null && which pkexec &>/dev/null
 }

--- a/lamw_manager/core/headers/lamw4linux_env.sh
+++ b/lamw_manager/core/headers/lamw4linux_env.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 LAMW_IDE_HOME_CFG="$LAMW_USER_HOME/.lamw4linux"

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 
@@ -11,7 +11,7 @@
 #										Section Version Variables
 #--------------------------------------------------------------------------------------------------
 
-LAMW_INSTALL_VERSION="0.6.2"
+LAMW_INSTALL_VERSION="0.6.3"
 ANT_VERSION_STABLE='1.10.11'
 CMD_SDK_TOOLS_VERSION="9123335"
 CMD_SDK_TOOLS_VERSION_STR="8.0"
@@ -51,7 +51,7 @@ OLD_LAZARUS_STABLE_VERSION=(
 )
 
 OLD_LAMW_INSTALL_VERSION=(
-	0.6.{1..0}
+	0.6.{2..0}
 	0.5.9{.{2..1},}
 	0.5.{8..0}
 	0.4.{8..4}

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (mater-alma)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: The "lamw-manager-settings-editor.sh" is part of the core of LAMW Manager. Responsible for managing LAMW Manager / LAMW configuration files..
 #-----------------------------------------------------------------------f--------------------------#
 

--- a/lamw_manager/core/settings-editor/root-lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/root-lamw-settings-editor.sh
@@ -15,21 +15,18 @@ checkisLocalRootLAMWInvalid(){
 		/usr{,/{bin,games,include,lib,lib32,libexec,libx32,local,sbin,share,src}}
 	)
 
-	for ((i = 0 ; i < ${#invalid_paths_pattern[@]};i++)); do
-
-		if [[ "$LOCAL_ROOT_LAMW" =~ ${invalid_paths_pattern[$i]} ]]; then 
-			echo "${VERMELHO}Fatal error${NORMAL}: You cannot install in ${VERMELHO}${LOCAL_ROOT_LAMW}${NORMAL} !!"
+	arrayMap invalid_paths_pattern pattern '
+		if [[ "$LOCAL_ROOT_LAMW" =~  $pattern ]]; then
+			echo "${VERMELHO}Fatal error${NORMAL}: You cannot install in ${VERMELHO}${LOCAL_ROOT_LAMW}${NORMAL} !!" &&
 			exit 1
-		fi
-	done
+		fi'
 
-	for ((i = 0 ; i < ${#invalid_paths[@]};i++)); do
-		if [ "$LOCAL_ROOT_LAMW" = "${invalid_paths[i]}" ]; then
+	arrayMap invalid_paths error_path '
+		if [ "$LOCAL_ROOT_LAMW" = "$error_path" ]; then
 			echo "${VERMELHO}Fatal error: this a Filesystem Hierarchy Standard (FHS) folder, need a  unique subfolder!${NORMAL}"
 			echo "${NEGRITO}Sample: LOCAL_ROOT_LAMW=$LOCAL_ROOT_LAMW/LAMW${NORMAL}"
-			exit 1;
-		fi
-	done
+			exit 1
+		fi'
 
 	[ -e "$LOCAL_ROOT_LAMW"  ] && mountpoint "$LOCAL_ROOT_LAMW" &> /dev/null
 	if [ $? = 0 ]; then

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -135,7 +135,30 @@ latestproject(){
 	fi
 }
 
+setForbiddenCommand(){
+	
+	local -A commands=(
+		["gnome-shell"]="\-\-replace"e
+	    ["kquitapp5"]="plasmashell"
+	    ["kstart"]="plasmashell"
+	    ["xfwm4"]="\-\-replace" 
+		["lxqt-panel"]="\-\-replace" 
+		["mate-panel"]="\-\-replace" 
+		["cinnamon"]="\-\-replace"
+	)
 
+	for command in "${!commands[@]}";do
+		pattern=${commands[$command]}
+		eval "function $command {
+			if [[ \"\$@\" =~ $pattern ]]; then
+				echo \"You cannot replace your desktop shell Here\"
+				return 1
+			fi
+			\$(which $command) \$@
+		}"
+		export -f $command
+	done
+}
 export -f $LAM4LINUX_TERMINAL_FUNCTIONS
 
 if [[ "$-" =~ (x) ]]; then
@@ -149,7 +172,7 @@ echo "Here you can run FPC command line tools, Lazarus and LAMW scripts"
 
 update-lamw-manager &
 
-
+setForbiddenCommand
 generateSDKToolsCommands
 cd $CURRENT_LAMW_WORKSPACE
 exec bash  $_EXTRA_ARGS $@

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -135,10 +135,10 @@ latestproject(){
 	fi
 }
 
-setForbiddenCommand(){
+setDesktopSessionReplaceProtection(){
 	
 	local -A commands=(
-		["gnome-shell"]="\-\-replace"e
+		["gnome-shell"]="\-\-replace"
 	    ["kquitapp5"]="plasmashell"
 	    ["kstart"]="plasmashell"
 	    ["xfwm4"]="\-\-replace" 
@@ -172,7 +172,7 @@ echo "Here you can run FPC command line tools, Lazarus and LAMW scripts"
 
 update-lamw-manager &
 
-setForbiddenCommand
+setDesktopSessionReplaceProtection
 generateSDKToolsCommands
 cd $CURRENT_LAMW_WORKSPACE
 exec bash  $_EXTRA_ARGS $@

--- a/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
+++ b/lamw_manager/core/settings-editor/templates/lamw4linux-terminalrc
@@ -150,7 +150,8 @@ setDesktopSessionReplaceProtection(){
 	for command in "${!commands[@]}";do
 		pattern=${commands[$command]}
 		eval "function $command {
-			if [[ \"\$@\" =~ $pattern ]]; then
+			forbiddenPattern=\"$pattern\"
+			if [[ \"\$@\" =~ \$forbiddenPattern ]]; then
 				echo \"You cannot replace your desktop shell Here\"
 				return 1
 			fi

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -2,6 +2,15 @@
 
 This page contains information about new features and bug fixes.
 
+v0.6.3 - 5 Feb, 2024
+---
+
+**Fixes**
++	Fix missing --avdmanager completation
++	Fix missing pkexec in *isSupportedPolkit*
++	Adds desktop session protection
+	+	Prevents desktop shell replace into lamw4linux-terminal
+
 v0.6.2 - Jan 28, 2024
 ---
 

--- a/lamw_manager/lamw_manager
+++ b/lamw_manager/lamw_manager
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.2
-#Date: 01/27/2024
+#Version: 0.6.3
+#Date: 02/04/2024
 #Description: The "lamw-install.sh" is part of the core of LAMW Manager. This script configures the development environment for LAMW
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/tests/tests-header
+++ b/lamw_manager/tests/tests-header
@@ -5,7 +5,9 @@ else
 	lamw_manager_script=$(realpath ../lamw_manager)	
 fi
 
-export HOME=$(mktemp -dt  danny.XXXXXXXXXXX)
+export HOME=$(mktemp -dt  home.XXXXXXX)
+mkdir -p "$HOME/$USER"
+export HOME="$HOME/$USER"
 export ROOT_LAMW=~/LAMW
 LAMW_MANAGER_MODULES_PATH=$(dirname $lamw_manager_script)/core
 source "$LAMW_MANAGER_MODULES_PATH/headers/common-shell.sh"


### PR DESCRIPTION
- fix missing --avdmanager completation
- replace for (loop) to arrayMap
- add desktop session protection
- rename setForbiddenCommand to setDesktopSessionReplaceProtection
- minor fixes in setDesktopSessionReplaceProtection
- check if pkexec is exists in $PATH
- get releases- in ci/cd
- rename tests folder
- prepare v0.6.3
- update docs to v0.6.3
- test ci/cd
- fix missing /tmp/lamw_manager_setup.sh
- debug in ci/cd ls  ~
- move build to create-and-release
- adjusts ci/cd
- fixes missing makeself
- rename tasks
- rename workflow
- update build badge
- update workflow
