### PR TITLE
v0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.6.4-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.4/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -58,7 +58,7 @@ LAMW Manager install the following [dependencies] tools:
 Getting Started!!
 ---
 **How to use LAMW Manager:**
-+	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh)
++	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.4/lamw_manager_setup.sh)
 +	Go to download directory and right click *Open in Terminal*
 +	Run command : *bash lamw_manager_setup.sh*¹
 
@@ -100,5 +100,5 @@ Congratulations!!
 ---
 You are now a Lazarus for Android developer!</br>[Building Android application with **LAMW** is **RAD**!](https://drive.google.com/open?id=1CeDDpuDfRwYrKpN7VHbossH6GfZUfqjm)
 
-For more info read [**LAMW Manager v0.6.3 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
+For more info read [**LAMW Manager v0.6.4 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Linux Distro Supported:
 **Note**: Only Linux **x86_64** bits is supported!
 <p>
 	<ul>
-		<li><img src="https://www.debian.org/logos/openlogo-nd.svg" style="width: 16px;"/> Debian GNU/ Linux 12</li>
+		<li><img src="https://www.debian.org/logos/openlogo-nd.svg" style="width: 16px;"/> Debian 12</li>
 		<li><img src="https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png" style="width: 16px;"/> Ubuntu 22.04 LTS</li>
 		<li><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/35/Tux.svg/249px-Tux.svg.png" style="width: 16px;"/> <a href="https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/other-distros-info.md">Requirements for other Linux</a>
 			<ul>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ LAMW Manager install the following [dependencies] tools:
 
 
 **Notes**
-1. The minimum Android API and Build Tools required by LAMW and specified in [*package.json*](https://github.com/jmpessoa/lazandroidmodulewizard/blob/v0.6.x/package.json) are installed 
+1. The minimum Android API and Build Tools required by LAMW and specified in [*package.json*](https://github.com/jmpessoa/lazandroidmodulewizard/blob/master/package.json) are installed 
 
 Getting Started!!
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.6.3-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.3/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -94,7 +94,7 @@ Recommended:
 
 Release Notes:
 ---
-For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#v063---feb-5-2024)
+For information on new features and bug fixes read the [*Release Notes*](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest)
 
 Congratulations!!
 ---

--- a/lamw_manager/assets/build-lamw-setup
+++ b/lamw_manager/assets/build-lamw-setup
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: This script generates compiles LAMW Manager source code into an executable installer.
 #Note: This script requires makeself, read more in https://makeself.io/
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/assets/get-releases-notes.sh
+++ b/lamw_manager/assets/get-releases-notes.sh
@@ -24,7 +24,7 @@ REGEX_VERSION_DELIMITER='(^###)'
 arrayMap  RELEASES_NOTES_STREAM line index '
 	if [[ "$line" =~ $VERSION_REGEX ]]; then
 		INDEX_MATCH_V=$index
-		break
+		return
 	fi'
 
 RELEASES_NOTES_STREAM=(${RELEASES_NOTES_STREAM[@]:$INDEX_MATCH_V})
@@ -33,7 +33,7 @@ arrayMap  RELEASES_NOTES_STREAM line index '
 	if [[ "$line" =~ $REGEX_VERSION_DELIMITER ]] && [ $index -gt $INDEX_MATCH_V ]; then
 		INDEX_END=$index
 		let INDEX_END-=1
-		break
+		return
 	fi'
 
 arraySlice RELEASES_NOTES_STREAM 0 $INDEX_END RELEASES_NOTES_STREAM_F

--- a/lamw_manager/assets/get-releases-notes.sh
+++ b/lamw_manager/assets/get-releases-notes.sh
@@ -19,6 +19,7 @@ VERSION=$(
 INDEX_MATCH_V=0
 INDEX_END=0
 VERSION_REGEX="$(GenerateScapesStr "$VERSION")"
+REGEX_VERSION_DELIMITER='(^###)'
 
 arrayMap  RELEASES_NOTES_STREAM line index '
 	if [[ "$line" =~ $VERSION_REGEX ]]; then
@@ -27,7 +28,7 @@ arrayMap  RELEASES_NOTES_STREAM line index '
 	fi'
 
 RELEASES_NOTES_STREAM=(${RELEASES_NOTES_STREAM[@]:$INDEX_MATCH_V})
-REGEX_VERSION_DELIMITER='(^###)'
+
 arrayMap  RELEASES_NOTES_STREAM line index '
 	if [[ "$line" =~ $REGEX_VERSION_DELIMITER ]] && [ $index -gt $INDEX_MATCH_V ]; then
 		INDEX_END=$index

--- a/lamw_manager/assets/get-releases-notes.sh
+++ b/lamw_manager/assets/get-releases-notes.sh
@@ -32,7 +32,6 @@ RELEASES_NOTES_STREAM=(${RELEASES_NOTES_STREAM[@]:$INDEX_MATCH_V})
 arrayMap  RELEASES_NOTES_STREAM line index '
 	if [[ "$line" =~ $REGEX_VERSION_DELIMITER ]] && [ $index -gt $INDEX_MATCH_V ]; then
 		INDEX_END=$index
-		let INDEX_END-=1
 		return
 	fi'
 

--- a/lamw_manager/assets/get-releases-notes.sh
+++ b/lamw_manager/assets/get-releases-notes.sh
@@ -27,8 +27,9 @@ arrayMap  RELEASES_NOTES_STREAM line index '
 	fi'
 
 RELEASES_NOTES_STREAM=(${RELEASES_NOTES_STREAM[@]:$INDEX_MATCH_V})
+REGEX_VERSION_DELIMITER='(^###)'
 arrayMap  RELEASES_NOTES_STREAM line index '
-	if [[ "$line" =~ "---" ]] && [ $index -gt $INDEX_MATCH_V ]; then
+	if [[ "$line" =~ $REGEX_VERSION_DELIMITER ]] && [ $index -gt $INDEX_MATCH_V ]; then
 		INDEX_END=$index
 		let INDEX_END-=1
 		break

--- a/lamw_manager/core/cross-builder/cross-builder.sh
+++ b/lamw_manager/core/cross-builder/cross-builder.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description:The "cross-builder.sh" is part of the core of LAMW Manager.  This script contains crosscompile compiler generation routines for ARMv7 / AARCH64- Android
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.init_lamw_manager.sh
+++ b/lamw_manager/core/headers/.init_lamw_manager.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: The ".init_lamw_manager.sh" is part of the core of LAMW Manager. This script check conditions to init LAMW Manager
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
+#Version: 0.6.4
 #Description: This script contains routines for completing LAMW Manager arguments.
 #Ref:https://www.vivaolinux.com.br/dica/Shell-script-autocompletion-Como-implementar
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/headers/lamw4linux_env.sh
+++ b/lamw_manager/core/headers/lamw4linux_env.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 LAMW_IDE_HOME_CFG="$LAMW_USER_HOME/.lamw4linux"

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 
@@ -11,7 +11,7 @@
 #										Section Version Variables
 #--------------------------------------------------------------------------------------------------
 
-LAMW_INSTALL_VERSION="0.6.3"
+LAMW_INSTALL_VERSION="0.6.4"
 ANT_VERSION_STABLE='1.10.11'
 CMD_SDK_TOOLS_VERSION="9123335"
 CMD_SDK_TOOLS_VERSION_STR="8.0"
@@ -51,7 +51,7 @@ OLD_LAZARUS_STABLE_VERSION=(
 )
 
 OLD_LAMW_INSTALL_VERSION=(
-	0.6.{2..0}
+	0.6.{3..0}
 	0.5.9{.{2..1},}
 	0.5.{8..0}
 	0.4.{8..4}

--- a/lamw_manager/core/headers/parser.sh
+++ b/lamw_manager/core/headers/parser.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-lamw_manager_help(){
-	local lamw_mgr="./lamw_manager"
+setLAMWManagerRunStr(){
+	LAMW_MANAGER_RUN="./lamw_manager"
 	if [ "$USE_SETUP" = "1" ]; then
-		lamw_mgr="bash lamw_manager_setup.sh\t${VERDE}--${NORMAL}"
+		LAMW_MANAGER_RUN="bash lamw_manager_setup.sh"
+	fi
+}
+
+lamw_manager_help(){
+	local lamw_mgr="$LAMW_MANAGER_RUN"
+	if [ "$USE_SETUP" = "1" ]; then
+		lamw_mgr="$LAMW_MANAGER_RUN\t${VERDE}--${NORMAL}"
 	fi
 
 	LAMW_OPTS=(
@@ -243,9 +250,9 @@ helloMessage(){
 	local style3=$'\e[1;'$italic'm'
 	local version_message="${style3}v${LAMW_INSTALL_VERSION}${NORMAL}"
 
-	local lamw_mgr="./lamw_manager"
+	local lamw_mgr="$LAMW_MANAGER_RUN"
 	if [ "$USE_SETUP" = "1" ]; then
-		lamw_mgr="bash lamw_manager_setup.sh\t${VERDE}--${NORMAL}"
+		lamw_mgr="$LAMW_MANAGER_RUN\t${VERDE}--${NORMAL}"
 	fi
 
 	if [ $NOBLINK =  0 ]; then 
@@ -273,6 +280,7 @@ parseOpts(){
 }
 
 initialConfig(){
+	setLAMWManagerRunStr
 	setSignalHandles
 	parseOpts
 	helloMessage 1>&2

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/lamw-mgr-core-os.sh
+++ b/lamw_manager/core/lamw-mgr-core-os.sh
@@ -46,7 +46,7 @@ checkRootLAMWInitStatus(){
 
 	if [ -e $parent ];then
 		if [ -O $parent ]; then
-				initROOT_LAMW
+			initROOT_LAMW
 		fi
 	fi
 

--- a/lamw_manager/core/lamw-mgr-core-os.sh
+++ b/lamw_manager/core/lamw-mgr-core-os.sh
@@ -92,10 +92,15 @@ mainInstall(){
 }
 
 LAMW4LinuxPostConfig(){
+	if [ -e  "$LAMW_MANAGER_CORE_LOCK" ]; then 
 		IsFileBusy  "postInstall actions" "$LAMW_MANAGER_CORE_LOCK" 
 		enableADBtoUdev
+	fi
+
+	if [ -e "$CROSSBIN_LOCK" ]; then 
 		IsFileBusy "crossbinLock" "$CROSSBIN_LOCK"
 		CleanOldCrossCompileBins
+	fi
 }
 
 

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -339,6 +339,12 @@ LAMW4LinuxPostConfig(){
 		ln -s "$LAMW_IDE_HOME/startlamw4linux" "$LAMW_USER_HOME/.local/bin/startlamw4linux"
 	fi
 
+	if [ -e  "$LAMW_USER_HOME/.local/bin/lamw4linux-terminal" ]; then
+		rm "$LAMW_USER_HOME/.local/bin/lamw4linux-terminal"
+	fi 
+
+	ln -s "$LAMW4LINUX_TERMINAL_EXEC_PATH" "$LAMW_USER_HOME/.local/bin/lamw4linux-terminal"
+	
 	if [ $IS_DEBIAN = 0 ]; then  
 		CheckIfSystemNeedTerminalMitigation
 		SystemTerminalMitigation 
@@ -484,6 +490,7 @@ CleanOldConfig(){
 		"/usr/lib/fpc/$FPC_VERSION/fpmkinst/arm-android"
 		"/usr/bin/startlamw4linux"
 		"$LAMW_USER_HOME/.local/bin/startlamw4linux"
+		"$LAMW_USER_HOME/.local/bin/lamw4linux-terminal"
 		"$FPC_CFG_PATH"
 		"$LAMW_IDE_HOME_CFG"
 		"$ROOT_LAMW"

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (mater-alma)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: The "lamw-manager-settings-editor.sh" is part of the core of LAMW Manager. Responsible for managing LAMW Manager / LAMW configuration files..
 #-----------------------------------------------------------------------f--------------------------#
 

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -19,7 +19,7 @@ Latest
 		+	~/.local/bin will be only in *\$PATH* if ~/.profile and ~/.bashrc are configured
 		+	Tip: if ~/.profile and ~/.bashrc does not exists:
 		
-```console
+```bash
 		cp /etc/skel/.profile ~
 		cp /etc/skel/.bashrc ~
 		# restart your session

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -2,8 +2,10 @@
 
 This page contains information about new features and bug fixes.
 
-v0.6.3 - 5 Feb, 2024
+Latest
 ---
+### v0.6.3 - 5 Feb, 2024 ###
+
 
 **Fixes**
 +	Fix missing --avdmanager completation
@@ -11,8 +13,8 @@ v0.6.3 - 5 Feb, 2024
 +	Adds desktop session protection
 	+	Prevents desktop shell replace into lamw4linux-terminal
 
-v0.6.2 - Jan 28, 2024
----
+### v0.6.2 - Jan 28, 2024 ###
+
 
 **Fixes**
 +	Fixes missing *--avdmanager* in releases notes.
@@ -23,8 +25,8 @@ v0.6.2 - Jan 28, 2024
 	+	**Tip**: run *update-lamw-manager get* to upgrade your *lamw4linux*
 	+ 	**Note**: this notification is show (only) when do you open *lamw4linux-terminal*
 
-v0.6.1 - Jan 22, 2024
----
+### v0.6.1 - Jan 22, 2024 ###
+
 
 **Warning**
 This repository underwent **maintenance** and had its **commits rewritten**, if you cloned this repository you will need to delete it and clone it again
@@ -36,8 +38,8 @@ This repository underwent **maintenance** and had its **commits rewritten**, if 
 +	Now you can run **avdmanager** from lamw_manager
 	+ use option *--avdmanager* to run Android Device Manager,
 
-v0.6.0 - Jan 15, 2024
----
+### v0.6.0 - Jan 15, 2024 ###
+
 
 **Fixes**
 +	Remove unecessary dependencie (like debian): *freeglut3*
@@ -60,8 +62,8 @@ v0.6.0 - Jan 15, 2024
 
 
 
-v0.5.9.2 - Jan 2, 2024
----
+### v0.5.9.2 - Jan 2, 2024 ###
+
 **Fixes**
 +	Fix try remove openjdk
 +	Prevents the tool from receiving SIGTERM/SIGINT<br/>in tasks that may compromise the integrity of the installation (atomic operations)
@@ -72,8 +74,8 @@ v0.5.9.2 - Jan 2, 2024
 	+	Reduces the need to rebuild Lazarus and FPC
 +	Use the progressbar in all time-consuming tasks
 
-v0.5.9.1 - Dec 27, 2023
----
+### v0.5.9.1 - Dec 27, 2023 ###
+
 **Fixes**
 +	Fixes cacheGradle
 +	Fixes missing debug options in lamw4linux-terminal: *-x* and *-v*
@@ -83,13 +85,13 @@ v0.5.9.1 - Dec 27, 2023
 	+	*latestproject* ( go to latest project folder )
 
 
-v0.5.9 - Dec 12, 2023
----
+### v0.5.9 - Dec 12, 2023 ###
+
 **News**
 +	Get JDK required by *package.json*
 
-v0.5.8 - Sep 25, 2023
----
+### v0.5.8 - Sep 25, 2023 ###
+
 **Fixes**
 +	Adjusts the terminal column size
 +	Fix progress bar cancellation message
@@ -98,8 +100,8 @@ v0.5.8 - Sep 25, 2023
 +	Add New sdkmanager tools
 	+	All items from *\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin*
 
-v0.5.7 - Sep 11, 2023
----
+### v0.5.7 - Sep 11, 2023 ###
+
 **Fixes**
 +	Repair cmdline-tools (remove version not supported by JDK 8/11)
 
@@ -109,14 +111,14 @@ v0.5.7 - Sep 11, 2023
 	+	**Note**: It is an experimental feature
 
 
-v0.5.6 - Jun 4, 2023
----
+### v0.5.6 - Jun 4, 2023 ###
+
 
 **Fixes**
 +	Fix duplicate attribute in FppkgConfigFile node	
 
-v0.5.5 - May 31, 2023
----
+### v0.5.5 - May 31, 2023 ###
+
 
 **News**
 +	Install *fpc-android.cfg* and *fppkg.cfg* using templates
@@ -126,8 +128,8 @@ v0.5.5 - May 31, 2023
 	+	**Note**: requires reinstallation
 
 
-v0.5.4 - May 13, 2023
----
+### v0.5.4 - May 13, 2023 ###
+
 
 **Fixes**
 +	Fixes getFixLp
@@ -138,8 +140,8 @@ v0.5.4 - May 13, 2023
 +	Adds slow running warnings on single core machines (or VMs)
 +	Remove unnecessary APT dependencies
 
-v0.5.3-r1 - Mar 9, 2023
----
+### v0.5.3-r1 - Mar 9, 2023 ###
+
 
 This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON** or **Manjaro**
 
@@ -152,7 +154,7 @@ This is a maintenance release, the upgrade to this release is intended for those
 **News**
 +	Added OpenSuse Docs
 
-v0.5.3 - Jan 7, 2023
+### v0.5.3 - Jan 7, 2023
 --
 **Fixes**
 +	Fixes fpc source code path in git (ambiguous path)
@@ -163,7 +165,7 @@ v0.5.3 - Jan 7, 2023
 	+	Use multi-thread in build lazarus
 	+	Do git clone *\-\-jobs* param.
 
-v0.5.2 - Dec 21, 2022
+### v0.5.2 - Dec 21, 2022
 --
 **Fixes**
 +	Remove unnecessary APT dependencies.
@@ -182,8 +184,8 @@ v0.5.2 - Dec 21, 2022
 +	Check tools download integrity before extracting
 
 
-v0.5.1 - Ago 18, 2022
----
+### v0.5.1 - Ago 18, 2022 ###
+
 **Fixes**
 +	Fixes missing /tmp/lamw_manager_setup.sh in assets/build-lamw-setup
 +	Fixes duplicate ```[safe]``` settings in *\~.gitconfig*
@@ -194,7 +196,7 @@ v0.5.1 - Ago 18, 2022
 +	Adds templates in [*settings-editor*](https://github.com/dosza/LAMWManager-linux/blob/master/lamw_manager/core/settings-editor)
 
 
-v0.5.0 - Jun 12, 2022
+### v0.5.0 - Jun 12, 2022
 --
 **Fixes**
 +	Fixes wrong ld path on try build lazarus project to linux/x86_64
@@ -205,8 +207,8 @@ v0.5.0 - Jun 12, 2022
 	+	advmanager
 	+	lamw_manager
 
-v0.4.8 - Mar 8, 2022
----
+### v0.4.8 - Mar 8, 2022 ###
+
 **Fixes**
 +	Fixes get LAMW Environment
 +	Adds validation before delete *\$ANDROID_HOME*, *\$GRADLE_HOME* from \~/.bashrc
@@ -221,16 +223,16 @@ v0.4.8 - Mar 8, 2022
 
 **Note**: LAMW4Linux Terminal your LAMW Workspace from \~/.lamw4linux/LAMW.ini !
 
-v0.4.7 - Feb 19, 2022
----
+### v0.4.7 - Feb 19, 2022 ###
+
 **News**
 +	Build LAMW Packages in silence mode
 +	Uninstall old gradle (from old package.json) automatically 
 + 	Verify duplicated export LAMW Environment
 +	Adjust *--minimal* to install only what is strictly necessary for LAMW development 
 
-v0.4.6 - Feb 11, 2022
----
+### v0.4.6 - Feb 11, 2022 ###
+
 **News:**
 +	Adds *lazbuild* startup script on *\$LAMW4LINUX_HOME/usr/bin* with PPC_CONFIG_PATH and --pcp params
 +	Build FPC and Lazarus base on silence mode
@@ -239,8 +241,8 @@ v0.4.6 - Feb 11, 2022
 **Fixes**
 +	Remove unnecessary *[core.cross-builder](https://github.com/dosza/LAMWManager-linux/tree/e1a9311804f66f19044a1a2150d721afe1624a08/lamw_manager/core/cross-builder)* functions
 
-v0.4.5 - Jan 26, 2022
----
+### v0.4.5 - Jan 26, 2022 ###
+
 **Fixes**
 +	Fixes missing *xmlstarlet*
 +	Remove deprecated code from subversion actions 
@@ -248,8 +250,8 @@ v0.4.5 - Jan 26, 2022
 **News**
 +	Autostart LAMW4Linux after first install
 
-v0.4.4 - Dec 31, 2021
----
+### v0.4.4 - Dec 31, 2021 ###
+
 **Fixes**
 +	Remove unnecessary files to fpc builder (*bootstrap*)
 
@@ -257,27 +259,27 @@ v0.4.4 - Dec 31, 2021
 +	Module [*api.sh*](https://github.com/dosza/LAMWManager-linux/tree/v0.4.3/lamw_manager/core/installer/api.sh) has renamed to [*services.sh*](https://github.com/dosza/LAMWManager-linux/tree/v0.4.4/lamw_manager/core/installer/services.sh)
 +	 Experimental mitigation to [*Xfce Terminal bug*](https://github.com/jmpessoa/lazandroidmodulewizard/issues/110)
 
-v0.4.3.1 - Dec 13, 2021
----
+### v0.4.3.1 - Dec 13, 2021 ###
+
 **Fixes**
 +	Get Current *\$ROOT_LAMW_PARENT*
 
-v0.4.3 - Dec 11, 2021
----
+### v0.4.3 - Dec 11, 2021 ###
+
 **Fixes**
 +	Fixed: Fix wrong permissions in *\$ROOT_LAMW* parent directory
 
 **News**
 +	The module [*api.sh*](https://github.com/dosza/LAMWManager-linux/tree/v0.4.3/lamw_manager/core/installer/api.sh)<br/>has been upgrated to get path of LAMW Packages *\*.lpk*
 
-v0.4.2.2 - Dec 2, 2021
----
+### v0.4.2.2 - Dec 2, 2021 ###
+
 **Fixes**
 +	Fix get Current *\$LAMW_MGR_CORE*
 
 
-v0.4.2.1 - Nov 15, 2021
----
+### v0.4.2.1 - Nov 15, 2021 ###
+
 **News**
 +	Stop Gradle before to run *lamw_manager*
 +   Move setRootLAMW, getRootLAMW to new module [*Root LAMW Settings Editor*](https://github.com/dosza/LAMWManager-linux/tree/v0.4.2/lamw_manager/core/settings-editor/root-lamw-settings-editor.sh)
@@ -287,8 +289,8 @@ v0.4.2.1 - Nov 15, 2021
 **Fixes**
 +	Fixes get instalation Status using *\$LOCAL_ROOT_LAMW*
 
-v0.4.2 - Out 26, 2021
----
+### v0.4.2 - Out 26, 2021 ###
+
 **Fixes**
 +	Fixes error on try add first *jButton* on Lazarus 2.2.0 RC1<br/>
 **Warning: Lazarus has been downgraded to version 2.0.12**
@@ -297,32 +299,32 @@ v0.4.2 - Out 26, 2021
 +	Add description of **LAMW4Linux** on Start Menu 
 
 
-v0.4.1.6 - Set 30, 2021
----
+### v0.4.1.6 - Set 30, 2021 ###
+
 **Fixes**
 +	Fixes GetCurrent LAMW Manager Version
 
 **News**
 +	Update Getting Started.txt
 
-v0.4.1.5 - Set 18, 2021
----
+### v0.4.1.5 - Set 18, 2021 ###
+
 **Fixed**
 +	Missing Google Play Store API
 +	Add install psmisc (APT) dependencie
 
-v0.4.1.4 - Set 16, 2021
----
+### v0.4.1.4 - Set 16, 2021 ###
+
 **News**
 +	Get JDK from [Adoptium](https://adoptium.net) API ( [sucessor of AdoptOpenJDK](https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/))
 
-v0.4.1.3 - Set 12, 2021
----
+### v0.4.1.3 - Set 12, 2021 ###
+
 **Fixes**
 +	Error on start lamw4linux on command line
 
-v0.4.1.2 - Aug 20, 2021
----
+### v0.4.1.2 - Aug 20, 2021 ###
+
 **News**
 +	Adds /Update\<FppkgConfigFile\> tag (*and attributes*)  in  \~/.lamw4linux/environmentoptions.xml
 
@@ -332,8 +334,8 @@ v0.4.1.2 - Aug 20, 2021
 	+	Recreate lamw4linux settings
 	+	Recreate LAMW.ini
 
-v0.4.1.1  - Aug 5, 2021
----
+### v0.4.1.1  - Aug 5, 2021 ###
+
 **News**
 +	Lazarus 2.2.0RC1
 +	Remove unnecessary verbose on extract files 
@@ -343,8 +345,8 @@ v0.4.1.1  - Aug 5, 2021
 **Fixed**
 +	Get Freepascal Sources from SourceForge (while FPC migrates to gitlab)
 
-v0.4.1 - Jul 27, 2021
----
+### v0.4.1 - Jul 27, 2021 ###
+
 **News**
 +	Apache Ant¹ is no longer officially supported
 +	JDK default (installed by LAMW Manager) version is *11* using build from *AdoptOpenJDK*
@@ -357,8 +359,8 @@ v0.4.1 - Jul 27, 2021
 
 1.	To continue using Apache Ant (hybrid install), you must use [*LAMW Manager Setup v0.4.0.x*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.4.0.10/lamw_manager_setup.sh) 
 
-v0.4.0.3 - Jul 28, 2021
----
+### v0.4.0.3 - Jul 28, 2021 ###
+
 **News:**
 +	Apache Ant 1.10.11
 +	Hybrid install: latest version that will work with Apache Ant!
@@ -368,8 +370,8 @@ v0.4.0.3 - Jul 28, 2021
 	+	FPC i386/amd64-android crosscompile ! 
 +	Removed code deprecated
 
-v0.4.0.2 - Jul 27, 2021
----
+### v0.4.0.2 - Jul 27, 2021 ###
+
 **News:**
 +	Apache Ant is no longer officially supported (*in fresh instalation*)
 +	Get Current Widget from idemake.cfg and pass to *lazbuild*
@@ -378,8 +380,8 @@ v0.4.0.2 - Jul 27, 2021
 +	Wrong permission: idemake.cfg
 +	Fix parser proxy options
 
-v0.4.0.1 - Jul 18, 2021
----
+### v0.4.0.1 - Jul 18, 2021 ###
+
 **News:**
 +	LAMW Manager now supports JDK 8 on Debian GNU/Linux 
 +	Now LAMW Manager installs OpenJDK in *$ROOT_LAMW/jdk*
@@ -388,8 +390,8 @@ v0.4.0.1 - Jul 18, 2021
 +	update-alternatives --config java no longer run on the system
 + 	*\$LAMW_USER* and *\$LAMW_USER_HOME* is passed by env command.
 
-v0.4.0 - Jun 20, 2021
----
+### v0.4.0 - Jun 20, 2021 ###
+
 **News:**
 +	Android NDK r22b
 +	FPC 3.2.0 has replaced to FPC 3.2.2
@@ -401,8 +403,8 @@ v0.4.0 - Jun 20, 2021
 +	Adds validation before delete files created by LAMW Manager
 
 
-v0.3.6.2 - May 6, 2021
----
+### v0.3.6.2 - May 6, 2021 ###
+
 **News:**
 +	Lazarus 2.0.12
 
@@ -411,15 +413,15 @@ v0.3.6.2 - May 6, 2021
 +	Prevent multiple lamw_manager instances execution!
 
 
-v0.3.6.1 - February 5, 2021
----
+### v0.3.6.1 - February 5, 2021 ###
+
 **Fixed:**
 +	Adds minimal build tools required by Gradle
 +	Setup android 29 libs on fpc.cfg
 
 
-v0.3.6 - November 23, 2020
----
+### v0.3.6 - November 23, 2020 ###
+
 **News:**
 +	Gradle 6.6.1
 +	Updates minimum usage requirements.
@@ -430,15 +432,15 @@ v0.3.6 - November 23, 2020
 +	Try run pkexec in tty
 
 
-v0.3.5 - R1 August 6, 2020
----
+### v0.3.5 - R1 August 6, 2020 ###
+
 **Fixed:**
 +	Missing Android API's
 +	Fixes: *--reset-aapis*
 
 
-v0.3.5 - July 19, 2020
----
+### v0.3.5 - July 19, 2020 ###
+
 **News:**
 +	Android NDK r21d
 +	Apache Ant 1.10.8
@@ -452,8 +454,8 @@ v0.3.5 - July 19, 2020
 **Fixed:**
 +	Missing *fpcres*
 
-v0.3.4 - R1 - May 20, 2020
----
+### v0.3.4 - R1 - May 20, 2020 ###
+
 **News:**
 +	Lazarus 2.0.8
 +	Update Lazarus version on \~/.lamw4linux/environmentoptions.xml
@@ -461,8 +463,8 @@ v0.3.4 - R1 - May 20, 2020
 **Fixed:**	
 +	Fixed --reset and --uninstall commands
 	
-v0.3.4 - March 10, 2020
----
+### v0.3.4 - March 10, 2020 ###
+
 **News:**
 +	Adds/fixs Path to FPCSourceDirectory  ~/.lamw4linux/environmentoptions.xml
 +	Optmization code on core/common-shell.sh
@@ -473,19 +475,19 @@ v0.3.4 - March 10, 2020
 +	Error: Exit without Install APT Dependencies
 +	Prevent error: install unrar packager
 	
-v0.3.3 - R2 - February 25, 2020
----
+### v0.3.3 - R2 - February 25, 2020 ###
+
 
 **Fixed:**
 +	Error: Build Lazarus with FPC 3.2.0
 	
-v0.3.3 - R1 - December 3, 2019
----
+### v0.3.3 - R1 - December 3, 2019 ###
+
 **Fixed:**	
 +	Error: Install APT Dependencies on Debian 10 Buster
 	
-v0.3.3 - November 26, 2019
----
+### v0.3.3 - November 26, 2019 ###
+
 **News:**
 +	Android NDK r20b
 +	Apache Ant 1.10.7
@@ -506,13 +508,13 @@ v0.3.3 - November 26, 2019
 +	Fixes incompatibility with *fpc-laz* and *lazarus-project*   
 		
 
-v0.3.2 - R1 - September 8, 2019
----
+### v0.3.2 - R1 - September 8, 2019 ###
+
 **Fixed:**
 +	Apache Ant URL
 
-v0.3.2 - August 19, 2019
----
+### v0.3.2 - August 19, 2019 ###
+
 **News:**
 +	FPC 3.2.0
 +	Lazarus 2.0.4
@@ -525,8 +527,8 @@ v0.3.2 - August 19, 2019
 +	PPC_CONFIG_PATH fixed
 +	FPC *trunk* has replaced to FPC 3.2.0
 		
-v0.3.1 - August 1, 2019
----
+### v0.3.1 - August 1, 2019 ###
+
 **News:**
 +	FPC 3.3.1(trunk)
 +	Build Freepascal - 3.3.1 x86_64/Linux
@@ -539,8 +541,8 @@ v0.3.1 - August 1, 2019
 **Fixed:**	
 +	Removed  unecessary messages!
 		
-v0.3.0 - May 10, 2019
----
+### v0.3.0 - May 10, 2019 ###
+
 **News:**
 +	Update FPC to 3.0.0 to 3.0.4 on Ubuntu 16.04/Linux Mint 18
 +	Adds Auto Repair to fixs FPC

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -4,8 +4,8 @@ This page contains information about new features and bug fixes.
 
 Latest
 ---
-### v0.6.3 - 5 Feb, 2024 ###
 
+### v0.6.3 - 5 Feb, 2024 ###
 
 **Fixes**
 +	Fix missing --avdmanager completation
@@ -14,7 +14,6 @@ Latest
 	+	Prevents desktop shell replace into lamw4linux-terminal
 
 ### v0.6.2 - Jan 28, 2024 ###
-
 
 **Fixes**
 +	Fixes missing *--avdmanager* in releases notes.
@@ -27,7 +26,6 @@ Latest
 
 ### v0.6.1 - Jan 22, 2024 ###
 
-
 **Warning**
 This repository underwent **maintenance** and had its **commits rewritten**, if you cloned this repository you will need to delete it and clone it again
 
@@ -39,7 +37,6 @@ This repository underwent **maintenance** and had its **commits rewritten**, if 
 	+ use option *--avdmanager* to run Android Device Manager,
 
 ### v0.6.0 - Jan 15, 2024 ###
-
 
 **Fixes**
 +	Remove unecessary dependencie (like debian): *freeglut3*
@@ -113,12 +110,10 @@ This repository underwent **maintenance** and had its **commits rewritten**, if 
 
 ### v0.5.6 - Jun 4, 2023 ###
 
-
 **Fixes**
 +	Fix duplicate attribute in FppkgConfigFile node	
 
 ### v0.5.5 - May 31, 2023 ###
-
 
 **News**
 +	Install *fpc-android.cfg* and *fppkg.cfg* using templates
@@ -130,7 +125,6 @@ This repository underwent **maintenance** and had its **commits rewritten**, if 
 
 ### v0.5.4 - May 13, 2023 ###
 
-
 **Fixes**
 +	Fixes getFixLp
 +	Fixes to non-debian systems
@@ -141,7 +135,6 @@ This repository underwent **maintenance** and had its **commits rewritten**, if 
 +	Remove unnecessary APT dependencies
 
 ### v0.5.3-r1 - Mar 9, 2023 ###
-
 
 This is a maintenance release, the upgrade to this release is intended for those who have problems with **CINNAMON** or **Manjaro**
 
@@ -155,7 +148,7 @@ This is a maintenance release, the upgrade to this release is intended for those
 +	Added OpenSuse Docs
 
 ### v0.5.3 - Jan 7, 2023
---
+
 **Fixes**
 +	Fixes fpc source code path in git (ambiguous path)
 +	Fixes missing bc
@@ -165,8 +158,8 @@ This is a maintenance release, the upgrade to this release is intended for those
 	+	Use multi-thread in build lazarus
 	+	Do git clone *\-\-jobs* param.
 
-### v0.5.2 - Dec 21, 2022
---
+### v0.5.2 - Dec 21, 2022 ###
+
 **Fixes**
 +	Remove unnecessary APT dependencies.
 +	Prevents lamw_manager from not installing in \~/snap and /usr/lib/lazarus folders

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -5,6 +5,15 @@ This page contains information about new features and bug fixes.
 Latest
 ---
 
+### v0.6.4 - 6 Feb, 2024 ###
+
+**Fixes**
++	Fixes *--update-lamw* outdated warning
+
+**News**
++	Now README.md always point to latest release
+
+
 ### v0.6.3 - 5 Feb, 2024 ###
 
 **Fixes**

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -12,6 +12,18 @@ Latest
 
 **News**
 +	Now README.md always point to latest release
++	Now you can run lamw4linux-terminal from command line
+	+	Notes:
+		+	lamw4linux-terminal and startlamw4linux is configured in *~/.local/bin*
+		+	if ~/.local/bin does not exists will be create
+		+	~/.local/bin will be only in *\$PATH* if ~/.profile and ~/.bashrc are configured
+		+	Tip: if ~/.profile and ~/.bashrc does not exists:
+		
+		```sh
+			cp /etc/skel/.profile ~
+			cp /etc/skel/.bashrc ~
+			# restart your session 
+		```
 
 
 ### v0.6.3 - 5 Feb, 2024 ###

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -19,12 +19,11 @@ Latest
 		+	~/.local/bin will be only in *\$PATH* if ~/.profile and ~/.bashrc are configured
 		+	Tip: if ~/.profile and ~/.bashrc does not exists:
 		
-		```sh
-			cp /etc/skel/.profile ~
-			cp /etc/skel/.bashrc ~
-			# restart your session 
-		```
-
+```console
+		cp /etc/skel/.profile ~
+		cp /etc/skel/.bashrc ~
+		# restart your session
+```
 
 ### v0.6.3 - 5 Feb, 2024 ###
 

--- a/lamw_manager/lamw_manager
+++ b/lamw_manager/lamw_manager
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.3
-#Date: 02/04/2024
+#Version: 0.6.4
+#Date: 02/06/2024
 #Description: The "lamw-install.sh" is part of the core of LAMW Manager. This script configures the development environment for LAMW
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/lamw_manager
+++ b/lamw_manager/lamw_manager
@@ -65,7 +65,7 @@ actions(){
 			Repair
 			if ! isUpdateLAMWDeps ; then
 				echo "${VERMELHO}Warning:There are updates for LAMW4Linux${NORMAL}"
-				echo "run ${NEGRITO}./lamw_manager to update:${NORMAL}"
+				echo "run ${NEGRITO} ${LAMW_MANAGER_RUN} to update:${NORMAL}"
 			fi
 			checkProxyStatus;
 			echo "Updating LAMW";

--- a/lamw_manager/tests/parse-tests.sh
+++ b/lamw_manager/tests/parse-tests.sh
@@ -68,5 +68,15 @@ testParseMinimalOpt(){
 	assertEquals "${ARGS[*]}" ""
 }
 
+testStLAMWManagerRunStr(){
+	unset USE_SETUP
+
+	setLAMWManagerRunStr
+	assertEquals "./lamw_manager" "$LAMW_MANAGER_RUN"
+	USE_SETUP=1
+	setLAMWManagerRunStr
+	assertEquals "bash lamw_manager_setup.sh" "$LAMW_MANAGER_RUN"
+}
+
 rm -rf $HOME
 . $(which shunit2 ) 


### PR DESCRIPTION
- update url of releases notes
- fixes get latest release
- move variable declaration
- fixes releases_notes.md
- fixes demos url
- opitimizes get-releases-notes.sh
- replace debian name
- remove unnecessary identation
- test if exists lamw_manager locks
- set LAMW_MANAGER_RUN
- add unit test to setLAMWManagerRunStr
- use $LAMW_MANAGER_RUN in ./lamw_manager
- prepare v0.6.4
- add lamw4linux-terminal in ~/.local/bin
- update releases notes to v0.6.4
- fixes missing line in release_notes.md
- update releases notes
- menor fixes in release_notes.md
