### PR TITLE
v0.6.5

### DIFF
--- a/lamw_manager/assets/build-lamw-setup
+++ b/lamw_manager/assets/build-lamw-setup
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: This script generates compiles LAMW Manager source code into an executable installer.
 #Note: This script requires makeself, read more in https://makeself.io/
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/cross-builder/cross-builder.sh
+++ b/lamw_manager/core/cross-builder/cross-builder.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description:The "cross-builder.sh" is part of the core of LAMW Manager.  This script contains crosscompile compiler generation routines for ARMv7 / AARCH64- Android
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.init_lamw_manager.sh
+++ b/lamw_manager/core/headers/.init_lamw_manager.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: The ".init_lamw_manager.sh" is part of the core of LAMW Manager. This script check conditions to init LAMW Manager
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
+#Version: 0.6.5
 #Description: This script contains routines for completing LAMW Manager arguments.
 #Ref:https://www.vivaolinux.com.br/dica/Shell-script-autocompletion-Como-implementar
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/headers/lamw4linux_env.sh
+++ b/lamw_manager/core/headers/lamw4linux_env.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 LAMW_IDE_HOME_CFG="$LAMW_USER_HOME/.lamw4linux"

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 
@@ -11,7 +11,7 @@
 #										Section Version Variables
 #--------------------------------------------------------------------------------------------------
 
-LAMW_INSTALL_VERSION="0.6.4"
+LAMW_INSTALL_VERSION="0.6.5"
 ANT_VERSION_STABLE='1.10.11'
 CMD_SDK_TOOLS_VERSION="9123335"
 CMD_SDK_TOOLS_VERSION_STR="8.0"
@@ -51,7 +51,7 @@ OLD_LAZARUS_STABLE_VERSION=(
 )
 
 OLD_LAMW_INSTALL_VERSION=(
-	0.6.{3..0}
+	0.6.{4..0}
 	0.5.9{.{2..1},}
 	0.5.{8..0}
 	0.4.{8..4}

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -574,14 +574,14 @@ CreateSDKSimbolicLinks(){
 #--------------------------AARCH64 SETTINGS--------------------------
 updateFpcAndroidDotCfg(){
 	local  -A fpc_android_changes=(
-		['\$LLVM_ANDROID_ARM_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/$ANDROID_SDK_TARGET"
+		['\$LLVM_ANDROID_ARM_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/30"
 		['\$GCC_ANDROID_ARM_PATH']="${ARM_ANDROID_TOOLS}"
-		['\$LLVM_ANDROID_AARCH64_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/$ANDROID_SDK_TARGET"
+		['\$LLVM_ANDROID_AARCH64_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/30"
 		['\$GCC_ANDROID_AARCH64_PATH']="$AARCH64_ANDROID_TOOLS"
 		['\$GCC_ANDROID_I386_PATH']="$I386_ANDROID_TOOLS"
-		['\$LLVM_ANDROID_I386_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/i686-linux-android/$ANDROID_SDK_TARGET"
+		['\$LLVM_ANDROID_I386_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/i686-linux-android/30"
 		['\$GCC_ANDROID_AMD64_PATH']="$AMD64_ANDROID_TOOLS"
-		['\$LLVM_ANDROID_AMD64_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android/$ANDROID_SDK_TARGET"
+		['\$LLVM_ANDROID_AMD64_LIB_PATH']="$ROOT_LAMW/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android/30"
 	)
 
 	arrayMap fpc_android_changes realPath templatePath '

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (mater-alma)
 #Course: Science Computer
-#Version: 0.6.4
-#Date: 02/06/2024
+#Version: 0.6.5
+#Date: 02/11/2024
 #Description: The "lamw-manager-settings-editor.sh" is part of the core of LAMW Manager. Responsible for managing LAMW Manager / LAMW configuration files..
 #-----------------------------------------------------------------------f--------------------------#
 

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -5,6 +5,11 @@ This page contains information about new features and bug fixes.
 Latest
 ---
 
+### v0.6.5 - 11 Feb, 2024 ###
+
+**Fixes**
++	Fix  android NDK LLVM linkage (missing library)
+
 ### v0.6.4 - 6 Feb, 2024 ###
 
 **Fixes**


### PR DESCRIPTION
- update url of releases notes
- fixes get latest release
- move variable declaration
- fixes releases_notes.md
- fixes demos url
- opitimizes get-releases-notes.sh
- replace debian name
- remove unnecessary identation
- test if exists lamw_manager locks
- set LAMW_MANAGER_RUN
- add unit test to setLAMWManagerRunStr
- use $LAMW_MANAGER_RUN in ./lamw_manager
- prepare v0.6.4
- add lamw4linux-terminal in ~/.local/bin
- update releases notes to v0.6.4
- fixes missing line in release_notes.md
- update releases notes
- menor fixes in release_notes.md
- prepare v0.6.5
- fixes ndk lib path
- update releases notes
