### PR TITLE
v0.6.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LAMW Manager
 
 
-[![Version](https://img.shields.io/badge/Release-v0.6.12-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.12/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
+[![Version](https://img.shields.io/badge/Release-v0.6.13-blue)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/release_notes.md#latest) [![Build-status](https://img.shields.io/github/actions/workflow/status/dosza/LAMWManager-linux/main.yml?branch=v0.6.x)](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.13/lamw_manager_setup.sh) [![license](https://img.shields.io/github/license/dosza/LAMWManager-linux)](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/LICENSE) [![Stars](https://img.shields.io/github/stars/dosza/LAMWManager-linux?style=default)](https://github.com/dosza/LAMWManager-linux/stargazers)
 
 LAMW Manager is a command line tool,like *APT*, to automate the **installation**, **configuration** and **upgrade**<br/>the framework [LAMW - Lazarus Android Module Wizard](https://github.com/jmpessoa/lazandroidmodulewizard)
 
@@ -58,7 +58,7 @@ LAMW Manager install the following [dependencies] tools:
 Getting Started!!
 ---
 **How to use LAMW Manager:**
-+	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.12/lamw_manager_setup.sh)
++	Click here to download [*LAMW Manager Setup*](https://github.com/dosza/LAMWManager-linux/releases/download/v0.6.13/lamw_manager_setup.sh)
 +	Go to download directory and right click *Open in Terminal*
 +	Run command : *bash lamw_manager_setup.sh*¹
 
@@ -105,5 +105,5 @@ Congratulations!!
 ---
 You are now a Lazarus for Android developer!</br>[Building Android application with **LAMW** is **RAD**!](https://drive.google.com/open?id=1CeDDpuDfRwYrKpN7VHbossH6GfZUfqjm)
 
-For more info read [**LAMW Manager v0.6.12 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
+For more info read [**LAMW Manager v0.6.13 Manual**](https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/man.md)
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Linux Distro Supported:
 **Note**: Only Linux **x86_64** bits is supported!
 <p>
 	<ul>
-		<li><img src="https://www.debian.org/logos/openlogo-nd.svg" style="width: 16px;"/> Debian 12</li>
-		<li><img src="https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png" style="width: 16px;"/> Ubuntu 22.04 LTS</li>
+		<li><img src="https://www.debian.org/logos/openlogo-nd.svg" style="width: 16px;"/> Debian 13</li>
+		<li><img src="https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png" style="width: 16px;"/> Ubuntu 26.04 LTS</li>
 		<li><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/35/Tux.svg/249px-Tux.svg.png" style="width: 16px;"/> <a href="https://github.com/dosza/LAMWManager-linux/blob/v0.6.x/lamw_manager/docs/other-distros-info.md">Requirements for other Linux</a>
 			<ul>
 				<li>

--- a/lamw_manager/assets/build-lamw-setup
+++ b/lamw_manager/assets/build-lamw-setup
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: This script generates compiles LAMW Manager source code into an executable installer.
 #Note: This script requires makeself, read more in https://makeself.io/
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/cross-builder/cross-builder.sh
+++ b/lamw_manager/core/cross-builder/cross-builder.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description:The "cross-builder.sh" is part of the core of LAMW Manager.  This script contains crosscompile compiler generation routines for ARMv7 / AARCH64- Android
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.init_lamw_manager.sh
+++ b/lamw_manager/core/headers/.init_lamw_manager.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: The ".init_lamw_manager.sh" is part of the core of LAMW Manager. This script check conditions to init LAMW Manager
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/headers/.lamw_comple.sh
+++ b/lamw_manager/core/headers/.lamw_comple.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
+#Version: 0.6.13
 #Description: This script contains routines for completing LAMW Manager arguments.
 #Ref:https://www.vivaolinux.com.br/dica/Shell-script-autocompletion-Como-implementar
 #-------------------------------------------------------------------------------------------------#

--- a/lamw_manager/core/headers/lamw4linux_env.sh
+++ b/lamw_manager/core/headers/lamw4linux_env.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 LAMW_IDE_HOME_CFG="$LAMW_USER_HOME/.lamw4linux"

--- a/lamw_manager/core/headers/lamw_headers
+++ b/lamw_manager/core/headers/lamw_headers
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: The "lamw_headers" is part of the core of LAMW Manager. This script contains LAMW Manager variables.
 #-------------------------------------------------------------------------------------------------#
 
@@ -11,11 +11,11 @@
 #										Section Version Variables
 #--------------------------------------------------------------------------------------------------
 
-LAMW_INSTALL_VERSION="0.6.12"
+LAMW_INSTALL_VERSION="0.6.13"
 ANT_VERSION_STABLE='1.10.11'
 CMD_SDK_TOOLS_VERSION="11076708"
 CMD_SDK_TOOLS_VERSION_STR="12.0"
-LAZARUS_STABLE_VERSION="4.4"
+LAZARUS_STABLE_VERSION="4.8"
 FPC_TRUNK_VERSION="3.2.2"
 FPC_LAZ_DEB_VERSION="2.0.12"
 FPC_DEB_VERSION="3.2.0-1"
@@ -51,7 +51,7 @@ OLD_LAZARUS_STABLE_VERSION=(
 )
 
 OLD_LAMW_INSTALL_VERSION=(
-	0.6.{11..0}
+	0.6.{12..0}
 	0.5.9{.{2..1},}
 	0.5.{8..0}
 	0.4.{8..4}
@@ -134,8 +134,8 @@ LAMW_INSTALL_WELCOME=(
 )
 
 LAMW_LINUX_SPP=(
-	"\t*Debian 12\n"
-	"\t*Ubuntu 22.04 LTS\n"
+	"\t*Debian 13\n"
+	"\t*Ubuntu 26.04 LTS\n"
 )
 
 LAMW4LINUX_TEMPLATES_PATHS+=(["$LAMW_MENU_ITEM_PATH"]="$LAMW_IDE_HOME/install/lazarus.desktop")

--- a/lamw_manager/core/headers/parser.sh
+++ b/lamw_manager/core/headers/parser.sh
@@ -209,7 +209,8 @@ testConnectionInternet(){
 
 	startProgressBar
 	
-	if ! ping google.com -q -c4 &>/dev/null; then
+
+	if ! nslookup google.com  &>/dev/null ; then
 		echo "${VERMELHO}Error:${NORMAL} check your internet connection"
 		sleep 0.02
 		stopProgressBarAsFail

--- a/lamw_manager/core/installer/installer.sh
+++ b/lamw_manager/core/installer/installer.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: "installer.sh" is part of the core of LAMW Manager. Contains routines for installing LAMW development environment
 #-------------------------------------------------------------------------------------------------#
 

--- a/lamw_manager/core/settings-editor/lamw-settings-editor.sh
+++ b/lamw_manager/core/settings-editor/lamw-settings-editor.sh
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (mater-alma)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: The "lamw-manager-settings-editor.sh" is part of the core of LAMW Manager. Responsible for managing LAMW Manager / LAMW configuration files..
 #-----------------------------------------------------------------------f--------------------------#
 

--- a/lamw_manager/docs/release_notes.md
+++ b/lamw_manager/docs/release_notes.md
@@ -5,6 +5,21 @@ This page contains information about new features and bug fixes.
 Latest
 --- 
 
+### v0.6.13 - 03 Jul, 2026 ###
+
+**News**
++	Migrate to Lazarus 4.8
++ Supports to:
+	+	Ubuntu 26.04
+	+	Debian 13
+
++ Remove support:
+	+	Debian 12
+	+ Ubuntu 22.04
+
+**Fixes**
++	Uses nslookup to check network status.
+
 ### v0.6.12 - 12 Nov, 2025 ###
 
 **News**

--- a/lamw_manager/lamw_manager
+++ b/lamw_manager/lamw_manager
@@ -2,8 +2,8 @@
 #-------------------------------------------------------------------------------------------------#
 #Universidade federal de Mato Grosso (Alma Mater)
 #Course: Science Computer
-#Version: 0.6.12
-#Date: 11/11/2025
+#Version: 0.6.13
+#Date: 07/03/2026
 #Description: The "lamw-install.sh" is part of the core of LAMW Manager. This script configures the development environment for LAMW
 #-------------------------------------------------------------------------------------------------#
 


### PR DESCRIPTION

v0.6.13
---

**News**
+	Migrate to Lazarus 4.8
+ Supports to:
	+	Ubuntu 26.04
	+	Debian 13

+ Remove support:
	+	Debian 12
	+ Ubuntu 22.04

**Fixes**
+	Uses nslookup to check network status.